### PR TITLE
Ra dspdc 690 add processing bucket emails

### DIFF
--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -19,4 +19,5 @@ module clinvar {
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
   access_emails = []
+  deletion_age = 30
 }

--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -18,6 +18,6 @@ module clinvar {
   k8s_scaled_cluster_max_size = 3
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
-  access_groups = ["clingendevs@broadinstitute.org"]
+  reader_groups = ["clingendevs@broadinstitute.org"]
   deletion_age_days = 30
 }

--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -18,4 +18,5 @@ module clinvar {
   k8s_scaled_cluster_max_size = 3
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
+  access_emails = []
 }

--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -18,6 +18,6 @@ module clinvar {
   k8s_scaled_cluster_max_size = 3
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
-  access_emails = []
-  deletion_age = 30
+  access_groups = []
+  deletion_age_days = 30
 }

--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -18,6 +18,6 @@ module clinvar {
   k8s_scaled_cluster_max_size = 3
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
-  access_groups = []
+  access_groups = ["clingendevs@broadinstitute.org"]
   deletion_age_days = 30
 }

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -44,7 +44,7 @@ resource google_storage_bucket staging_storage {
 
 resource google_storage_bucket_iam_member staging_iam_reader {
   # for_each doesn't like lists, so we convert it to a set
-  for_each = toset(var.access_groups)
+  for_each = toset(var.reader_groups)
 
   provider = google.target
   bucket = google_storage_bucket.staging_storage.name

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -30,7 +30,7 @@ resource google_storage_bucket staging_storage {
   location = "US"
 
   dynamic "lifecycle_rule" {
-    for_each = var.deletion_age == null ? [] : [var.deletion_age]
+    for_each = var.deletion_age_days == null ? [] : [var.deletion_age_days]
     content {
       action {
         type = "Delete"
@@ -42,14 +42,14 @@ resource google_storage_bucket staging_storage {
   }
 }
 
-resource google_storage_bucket_iam_member test_iam {
+resource google_storage_bucket_iam_member staging_iam_reader {
   # for_each doesn't like lists, so we convert it to a set
-  for_each = toset(var.access_emails)
+  for_each = toset(var.access_groups)
 
   provider = google.target
   bucket = google_storage_bucket.staging_storage.name
   # The legacyBucketReader policy seems to be the correct role to have the equivalent of a "Bucket Reader" ACL,
   # as noted here https://cloud.google.com/storage/docs/access-control/iam
   role = "roles/storage.legacyBucketReader"
-  member = "user:${each.value}"
+  member = "group:${each.value}"
 }

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -29,14 +29,15 @@ resource google_storage_bucket staging_storage {
   name = "${var.project_name}-staging-storage"
   location = "US"
 
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-
-    # Delete files after they've been in the bucket for 30 days.
-    condition {
-      age = 30
+  dynamic "lifecycle_rule" {
+    for_each = var.deletion_age == null ? [] : [var.deletion_age]
+    content {
+      action {
+        type = "Delete"
+      }
+      condition {
+        age = lifecycle_rule.value
+      }
     }
   }
 }

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -42,7 +42,7 @@ resource google_storage_bucket staging_storage {
 }
 
 resource google_storage_bucket_iam_member test_iam {
-
+  # for_each doesn't like lists, so we convert it to a set
   for_each = toset(var.access_emails)
 
   provider = google.target

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -24,7 +24,6 @@ resource google_storage_bucket temp_bucket {
 }
 
 # Bucket for temporary data storage.
-# TODO: Add an IAM resource which allows the repo to read from this.
 resource google_storage_bucket staging_storage {
   provider = google.target
   name = "${var.project_name}-staging-storage"
@@ -40,4 +39,17 @@ resource google_storage_bucket staging_storage {
       age = 30
     }
   }
+}
+
+resource google_storage_bucket_iam_member test_iam {
+
+  for_each = toset(var.access_emails)
+
+  provider = google.target
+  bucket = google_storage_bucket.staging_storage.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role = "roles/storage.legacyBucketReader"
+  member = "user:${each.value}"
 }

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -47,9 +47,8 @@ resource google_storage_bucket_iam_member test_iam {
 
   provider = google.target
   bucket = google_storage_bucket.staging_storage.name
-  # When the storage.admin role is applied to an individual bucket,
-  # the control applies only to the specified bucket and objects within
-  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  # The legacyBucketReader policy seems to be the correct role to have the equivalent of a "Bucket Reader" ACL,
+  # as noted here https://cloud.google.com/storage/docs/access-control/iam
   role = "roles/storage.legacyBucketReader"
   member = "user:${each.value}"
 }

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -40,5 +40,5 @@ variable kubeconfig_path {
 
 variable access_emails {
   type = list(string)
-  description = "Extra emails to share bucket access with."
+  description = "Emails to share bucket read access with."
 }

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -42,3 +42,8 @@ variable access_emails {
   type = list(string)
   description = "Emails to share bucket read access with."
 }
+
+variable deletion_age {
+  type = number
+  description = "The number of days to wait before deleting files in the staging bucket."
+}

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -37,3 +37,8 @@ variable kubeconfig_path {
   type = string
   description = "Local path where kubeconfig for the processing GKE cluster should be written."
 }
+
+variable access_emails {
+  type = list(string)
+  description = "Extra emails to share bucket access with."
+}

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -38,7 +38,7 @@ variable kubeconfig_path {
   description = "Local path where kubeconfig for the processing GKE cluster should be written."
 }
 
-variable access_groups {
+variable reader_groups {
   type = list(string)
   description = "Email addresses that represent google groups to share bucket read access with."
 }

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -38,12 +38,12 @@ variable kubeconfig_path {
   description = "Local path where kubeconfig for the processing GKE cluster should be written."
 }
 
-variable access_emails {
+variable access_groups {
   type = list(string)
-  description = "Emails to share bucket read access with."
+  description = "Email addresses that represent google groups to share bucket read access with."
 }
 
-variable deletion_age {
+variable deletion_age_days {
   type = number
   description = "The number of days to wait before deleting files in the staging bucket."
 }


### PR DESCRIPTION
Add the ability to write out what user accounts (email addresses) should have access to the staging bucket of a processing project. Not 100% sure that the role is right but pretty darn sure about it. I'm also assuming we don't need the delay thing that we used for service accounts because these are user accounts, not service accounts; if that assumption is wrong, I can fix it!

Used the `for_each` pattern listed under the "Resource for_each" in this https://www.hashicorp.com/blog/hashicorp-terraform-0-12-preview-for-and-for-each/

I convert the input `list` into a set using `toset` because the `for_each` pattern doesn't like lists.

(Also added the `access_emails` variable to clinvar's use of the processing project and currently the emails are set to an empty list)

**NOTE** That this PR now also adds the optional/configurable TTL on the staging bucket as detailed in [DSPDC-692](https://broadinstitute.atlassian.net/secure/RapidBoard.jspa?rapidView=495&modal=detail&selectedIssue=DSPDC-692)