### PR TITLE
Sw dspdc 670 Set up CloudSQL Proxy in dev environment

### DIFF
--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -216,7 +216,7 @@ function install_secrets_manager () {
 #####
 ## Set up Google's CloudSQL Proxy to communicate with the CloudSQL database.
 #####
-function install-cloudsql-proxy () {
+function install_cloudsql_proxy () {
   local -r kubeconfig=$1 env_dir=$2 env=$3
 
   # Configure helm
@@ -300,7 +300,7 @@ function main () {
   # Install command-center services.
   install_flux ${command_center_config} ${env_dir}
   install_secrets_manager ${command_center_config} ${env_dir} ${env}
-  install-cloudsql-proxy ${command_center_config} ${env_dir} ${env}
+  install_cloudsql_proxy ${command_center_config} ${env_dir} ${env}
   install_charts
 }
 

--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -179,7 +179,6 @@ function install_flux () {
     --set='rbac.pspEnabled=true'
 }
 
-
 #####
 ## Set up and install the Vault secret manager in the command center GKE cluster.
 #####
@@ -221,13 +220,13 @@ function install-cloudsql-proxy () {
   local -r kubeconfig=$1 env_dir=$2
 
   # Configure helm
-  declare -ra helm=($(configure_helm ${kubeconfig} ${env_dir}))
+  local -ra helm=($(configure_helm ${kubeconfig} ${env_dir}))
 
   # Read cloudsql configuration info from vault
   local -r vault_location=secret/dsde/monster/dev/command-center/cloudsql/instance
-  local -r instance_name=(vault read -field=name $vault_location)
-  local -r region=(vault read -field=region $vault_location)
-  local -r project=(vault read -field=project $vault_location)
+  local -r name=$(vault read -field=name $vault_location)
+  local -r region=$(vault read -field=region $vault_location)
+  local -r project=$(vault read -field=project $vault_location)
 
   # Add helm repo
   ${helm[@]} repo add datarepo-helm https://broadinstitute.github.io/datarepo-helm
@@ -242,14 +241,14 @@ function install-cloudsql-proxy () {
 
   # Install and upgrade CloudSQL Proxy
   ${helm[@]} upgrade --install pg-sqlproxy datarepo-helm/gcloud-sqlproxy --namespace cloudsql-proxy \
-    --set cloudsql.instances[0].instance=$instance_name \
+    --version=0.19.4 \
+    --set cloudsql.instances[0].instance=$name \
     --set cloudsql.instances[0].project=$project \
     --set cloudsql.instances[0].region=$region \
     --set cloudsql.instances[0].port=5432 -i \
     --set rbac.create=true \
     --set existingSecret=cloudsqlkey \
     --set existingSecretKey=cloudsqlkey.json
-
 }
 
 

--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -217,13 +217,13 @@ function install_secrets_manager () {
 ## Set up Google's CloudSQL Proxy to communicate with the CloudSQL database.
 #####
 function install-cloudsql-proxy () {
-  local -r kubeconfig=$1 env_dir=$2
+  local -r kubeconfig=$1 env_dir=$2 env=$3
 
   # Configure helm
   local -ra helm=($(configure_helm ${kubeconfig} ${env_dir}))
 
   # Read cloudsql configuration info from vault
-  local -r vault_location=secret/dsde/monster/dev/command-center/cloudsql/instance
+  local -r vault_location=secret/dsde/monster/${env}/command-center/cloudsql/instance
   local -r name=$(vault read -field=name $vault_location)
   local -r region=$(vault read -field=region $vault_location)
   local -r project=$(vault read -field=project $vault_location)
@@ -300,7 +300,7 @@ function main () {
   # Install command-center services.
   install_flux ${command_center_config} ${env_dir}
   install_secrets_manager ${command_center_config} ${env_dir} ${env}
-  install-cloudsql-proxy ${command_center_config} ${env_dir}
+  install-cloudsql-proxy ${command_center_config} ${env_dir} ${env}
   install_charts
 }
 

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -91,6 +91,8 @@ resource vault_generic_secret postgres_connection_name {
   data_json = <<EOT
 {
   "name": "${google_sql_database_instance.postgres.name}",
+  "region": "${google_sql_database_instance.postgres.project}",
+  "project": "${google_sql_database_instance.postgres.region}",
   "connection_name": "${google_sql_database_instance.postgres.connection_name}",
   "proxy_account_key": ${jsonencode(base64decode(google_service_account_key.cloudsql_proxy_account_key.private_key))}
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -91,8 +91,8 @@ resource vault_generic_secret postgres_connection_name {
   data_json = <<EOT
 {
   "name": "${google_sql_database_instance.postgres.name}",
-  "region": "${google_sql_database_instance.postgres.project}",
-  "project": "${google_sql_database_instance.postgres.region}",
+  "region": "${google_sql_database_instance.postgres.region}",
+  "project": "${google_sql_database_instance.postgres.project}",
   "connection_name": "${google_sql_database_instance.postgres.connection_name}",
   "proxy_account_key": ${jsonencode(base64decode(google_service_account_key.cloudsql_proxy_account_key.private_key))}
 }


### PR DESCRIPTION
Created a new function in `init-environment.sh` to set up CloudSQL Proxy. The function:
1. Configures helm
2. Reads config values from vault and writes them to GKE 
3. Installs or upgrades CloudSQL Proxy with the necessary secrets and other configs

Also, these changes update terraform to write the CloudSQL region and project name to vault.