### PR TITLE
Ra dspdc 696 google sa module

### DIFF
--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -4,39 +4,13 @@ resource google_storage_bucket monster_test_bucket {
   name = "monster-test-bucket"
   location = "US"
 }
-# a service account
-resource google_service_account test_sa {
-  provider = google-beta.command-center
+
+module test_sa {
+  source = "/templates/google-sa"
+
   account_id = "monster-dev-test-sa"
   display_name = "test-sa"
-}
-
-# a key associated with the service account
-resource google_service_account_key test_sa_key {
-  service_account_id = google_service_account.test_sa.name
-}
-
-# a vault secret containing the JSON key for the service account
-resource vault_generic_secret test_secret {
-  path = "${local.vault_prefix}/gcs/gcs-transfer-user-key"
-  data_json = <<EOT
-{
-  "sa_key": ${jsonencode(base64decode(google_service_account_key.test_sa_key.private_key))}
-}
-EOT
-}
-
-# NOTE: SAs created through Terraform are eventually-consistent, so we need to inject
-# an arbitrary delay between creating the account and applying IAM rules.
-# See: https://www.terraform.io/docs/providers/google/r/google_service_account.html
-# And: https://github.com/hashicorp/terraform/issues/17726#issuecomment-377357866
-resource null_resource test-proxy-delay {
-  provisioner "local-exec" {
-    command = "sleep 10"
-  }
-  triggers = {
-    "before" = google_service_account.test_sa.unique_id
-  }
+  vault_path = "${local.vault_prefix}/gcs/gcs-transfer-user-key"
 }
 
 resource google_storage_bucket_iam_member test_iam {
@@ -46,6 +20,6 @@ resource google_storage_bucket_iam_member test_iam {
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
   role = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.test_sa.email}"
-  depends_on = [null_resource.test-proxy-delay]
+  member = "serviceAccount:${module.test_sa.email}"
+  depends_on = [module.test_sa.delay]
 }

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -7,6 +7,9 @@ resource google_storage_bucket monster_test_bucket {
 
 module test_sa {
   source = "/templates/google-sa"
+  providers = {
+    google.target = google-beta.command-center
+  }
 
   account_id = "monster-dev-test-sa"
   display_name = "test-sa"

--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -231,7 +231,7 @@ function install_cloudsql_proxy () {
   local -r region=$(vault read -field=region $vault_location)
   local -r project=$(vault read -field=project $vault_location)
 
-  local -r vault_sa_location=secret/dsde/monster/${env}/command-conter/gcs/sa-key
+  local -r vault_sa_location=secret/dsde/monster/${env}/command-center/gcs/sa-key
 
   # Add helm repo
   ${helm[@]} repo add datarepo-helm https://broadinstitute.github.io/datarepo-helm

--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -241,7 +241,7 @@ function install_cloudsql_proxy () {
     --version=0.0.5 \
     --set secrets[0].secretName=cloudsqlkey \
     --set secrets[0].vals[0].kubeSecretKey=cloudsqlkey.json \
-    --set secrets[0].vals[0].path=vault_sa_location \
+    --set secrets[0].vals[0].path=$vault_sa_location \
     --set secrets[0].vals[0].vaultKey=sa_key
 
   # Install and upgrade CloudSQL Proxy

--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -23,7 +23,7 @@ declare -ra PROCESSING_NAMESPACES=(
   secrets-manager
 )
 
-declare -r TERRAFORM=hashicorp/terraform:0.12.17
+declare -r TERRAFORM=hashicorp/terraform:0.12.20
 declare -r KUBECTL=lachlanevenson/k8s-kubectl:v1.14.10
 declare -r HELM=lachlanevenson/k8s-helm:v3.0.2
 
@@ -231,6 +231,8 @@ function install_cloudsql_proxy () {
   local -r region=$(vault read -field=region $vault_location)
   local -r project=$(vault read -field=project $vault_location)
 
+  local -r vault_sa_location=secret/dsde/monster/${env}/command-conter/gcs/sa-key
+
   # Add helm repo
   ${helm[@]} repo add datarepo-helm https://broadinstitute.github.io/datarepo-helm
 
@@ -239,8 +241,8 @@ function install_cloudsql_proxy () {
     --version=0.0.5 \
     --set secrets[0].secretName=cloudsqlkey \
     --set secrets[0].vals[0].kubeSecretKey=cloudsqlkey.json \
-    --set secrets[0].vals[0].path=$vault_location \
-    --set secrets[0].vals[0].vaultKey=proxy_account_key
+    --set secrets[0].vals[0].path=vault_sa_location \
+    --set secrets[0].vals[0].vaultKey=sa_key
 
   # Install and upgrade CloudSQL Proxy
   ${helm[@]} upgrade --install pg-sqlproxy datarepo-helm/gcloud-sqlproxy --namespace cloudsql-proxy \

--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -242,7 +242,7 @@ function install_cloudsql_proxy () {
     --set secrets[0].secretName=cloudsqlkey \
     --set secrets[0].vals[0].kubeSecretKey=cloudsqlkey.json \
     --set secrets[0].vals[0].path=$vault_sa_location \
-    --set secrets[0].vals[0].vaultKey=sa_key
+    --set secrets[0].vals[0].vaultKey=key
 
   # Install and upgrade CloudSQL Proxy
   ${helm[@]} upgrade --install pg-sqlproxy datarepo-helm/gcloud-sqlproxy --namespace cloudsql-proxy \

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -44,44 +44,19 @@ resource google_sql_database_instance postgres {
   }
 }
 
-# Create an admin account for connecting to the DB using Google's cloudsql-proxy,
-# and give it the IAM role it needs to actually connect.
-#
-# NOTE: The way GCP IAM works, this account can be used for any CloudSQL instance
-# in the command-center project. We don't need an account per DB if we end up
-# needing multiple DBs.
-resource google_service_account cloudsql_proxy_account {
-  provider = google.target
-  depends_on = [module.enable_services]
+module test_sa {
+  source = "/templates/google-sa"
 
   account_id = "cloudsql-proxy-account"
   display_name = "CloudSQL proxy account"
-}
-# NOTE: SAs created through Terraform are eventually-consistent, so we need to inject
-# an arbitrary delay between creating the account and applying IAM rules.
-# See: https://www.terraform.io/docs/providers/google/r/google_service_account.html
-# And: https://github.com/hashicorp/terraform/issues/17726#issuecomment-377357866
-resource null_resource cloudsql_proxy_account_delay {
-  provisioner local-exec {
-    command = "sleep 10"
-  }
-  triggers = {
-    before = google_service_account.cloudsql_proxy_account.unique_id
-  }
-}
-resource google_project_iam_member cloudsql_proxy_account_iam {
-  provider = google.target
-  depends_on = [null_resource.cloudsql_proxy_account_delay]
-
-  role = "roles/cloudsql.client"
-  member = "serviceAccount:${google_service_account.cloudsql_proxy_account.email}"
+  vault_path = "${var.vault_prefix}/gcs/gcs-transfer-user-key"
+  roles = ["roles/cloudsql.client"]
 }
 
-# Create an access key for the account.
-resource google_service_account_key cloudsql_proxy_account_key {
-  provider = google.target
-  service_account_id = google_service_account.cloudsql_proxy_account.name
-}
+
+# TODO does the secret below need the proxy_account_key too, or is it fine to store
+# it where we have already stored it in the service account module? If it is needed
+# below, we have to expose the private_key as an output for the above module
 
 # Store all the info needed to connect to the DB instance in Vault.
 resource vault_generic_secret postgres_connection_name {
@@ -92,7 +67,7 @@ resource vault_generic_secret postgres_connection_name {
 {
   "name": "${google_sql_database_instance.postgres.name}",
   "connection_name": "${google_sql_database_instance.postgres.connection_name}",
-  "proxy_account_key": ${jsonencode(base64decode(google_service_account_key.cloudsql_proxy_account_key.private_key))}
+  "proxy_account_key": ${jsonencode(base64decode(module.test_sa.private_key))}
 }
 EOT
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -44,8 +44,11 @@ resource google_sql_database_instance postgres {
   }
 }
 
-module test_sa {
+module cloudsql_sa {
   source = "/templates/google-sa"
+  providers = {
+    google.target = google.target
+  }
 
   account_id = "cloudsql-proxy-account"
   display_name = "CloudSQL proxy account"
@@ -63,7 +66,7 @@ resource vault_generic_secret postgres_connection_name {
   "name": "${google_sql_database_instance.postgres.name}",
   "region": "${google_sql_database_instance.postgres.region}",
   "project": "${google_sql_database_instance.postgres.project}",
-  "connection_name": "${google_sql_database_instance.postgres.connection_name}",
+  "connection_name": "${google_sql_database_instance.postgres.connection_name}"
 }
 EOT
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -66,8 +66,7 @@ resource vault_generic_secret postgres_connection_name {
   data_json = <<EOT
 {
   "name": "${google_sql_database_instance.postgres.name}",
-  "connection_name": "${google_sql_database_instance.postgres.connection_name}",
-  "proxy_account_key": ${jsonencode(base64decode(module.test_sa.private_key))}
+  "connection_name": "${google_sql_database_instance.postgres.connection_name}"
 }
 EOT
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -49,16 +49,11 @@ module test_sa {
 
   account_id = "cloudsql-proxy-account"
   display_name = "CloudSQL proxy account"
-  vault_path = "${var.vault_prefix}/gcs/gcs-transfer-user-key"
+  vault_path = "${var.vault_prefix}/gcs/sa-key"
   roles = ["roles/cloudsql.client"]
 }
 
-
-# TODO does the secret below need the proxy_account_key too, or is it fine to store
-# it where we have already stored it in the service account module? If it is needed
-# below, we have to expose the private_key as an output for the above module
-
-# Store all the info needed to connect to the DB instance in Vault.
+# Store info needed to connect to the DB instance in Vault.
 resource vault_generic_secret postgres_connection_name {
   provider = vault.target
 
@@ -69,7 +64,6 @@ resource vault_generic_secret postgres_connection_name {
   "region": "${google_sql_database_instance.postgres.region}",
   "project": "${google_sql_database_instance.postgres.project}",
   "connection_name": "${google_sql_database_instance.postgres.connection_name}",
-  "proxy_account_key": ${jsonencode(base64decode(google_service_account_key.cloudsql_proxy_account_key.private_key))}
 }
 EOT
 }

--- a/templates/terraform/google-sa/README.md
+++ b/templates/terraform/google-sa/README.md
@@ -1,0 +1,5 @@
+# Google Service Account
+
+This module creates a Google Service account.
+It creates a key associated with the account and writes
+it to Vault, then creates IAM roles for the account.

--- a/templates/terraform/google-sa/main.tf
+++ b/templates/terraform/google-sa/main.tf
@@ -15,7 +15,7 @@ resource vault_generic_secret sa_secret {
   path = var.vault_path
   data_json = <<EOT
 {
-  "sa_key": ${jsonencode(base64decode(google_service_account_key.sa_key.private_key))}
+  "key": ${jsonencode(base64decode(google_service_account_key.sa_key.private_key))}
 }
 EOT
 }

--- a/templates/terraform/google-sa/main.tf
+++ b/templates/terraform/google-sa/main.tf
@@ -1,0 +1,44 @@
+# a service account
+resource google_service_account sa {
+  provider = google.target
+  account_id = var.account_id
+  display_name = var.display_name
+}
+
+# a key associated with the service account
+resource google_service_account_key sa_key {
+  service_account_id = google_service_account.sa.name
+}
+
+# a vault secret containing the JSON key for the service account
+resource vault_generic_secret sa_secret {
+  path = var.vault_path
+  data_json = <<EOT
+{
+  "sa_key": ${jsonencode(base64decode(google_service_account_key.sa_key.private_key))}
+}
+EOT
+}
+
+# NOTE: SAs created through Terraform are eventually-consistent, so we need to inject
+# an arbitrary delay between creating the account and applying IAM rules.
+# See: https://www.terraform.io/docs/providers/google/r/google_service_account.html
+# And: https://github.com/hashicorp/terraform/issues/17726#issuecomment-377357866
+resource null_resource sa_delay {
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
+  triggers = {
+    "before" = google_service_account.sa.unique_id
+  }
+}
+
+resource google_project_iam_member sa_iam {
+  for_each = toset(var.roles)
+
+  provider = google.target
+  depends_on = [null_resource.sa_delay]
+
+  role = each.value
+  member = "serviceAccount:${google_service_account.sa.email}"
+}

--- a/templates/terraform/google-sa/outputs.tf
+++ b/templates/terraform/google-sa/outputs.tf
@@ -1,0 +1,7 @@
+output email {
+  value = google_service_account.sa.email
+}
+
+output delay {
+  value = null_resource.sa_delay
+}

--- a/templates/terraform/google-sa/provider.tf
+++ b/templates/terraform/google-sa/provider.tf
@@ -1,0 +1,3 @@
+provider google {
+  alias = "target"
+}

--- a/templates/terraform/google-sa/variables.tf
+++ b/templates/terraform/google-sa/variables.tf
@@ -1,0 +1,21 @@
+variable account_id {
+  type = string
+  description = "Service account name."
+}
+
+variable display_name {
+  type = string
+  description = "The display name shown in the cloud console for the service account."
+  default = null
+}
+
+variable vault_path {
+  type = string
+  description = "Vault path to the relevant GCS key."
+}
+
+variable roles {
+  type = list(string)
+  description = "A list of roles for the service account to have."
+  default = []
+}

--- a/templates/terraform/google-sa/variables.tf
+++ b/templates/terraform/google-sa/variables.tf
@@ -1,17 +1,17 @@
 variable account_id {
   type = string
-  description = "Service account name."
+  description = "Name to assign to the new account."
 }
 
 variable display_name {
   type = string
-  description = "The display name shown in the cloud console for the service account."
+  description = "Display name to assign to the new account."
   default = null
 }
 
 variable vault_path {
   type = string
-  description = "Vault path to the relevant GCS key."
+  description = "Vault path where the new account's GCS key should be stored."
 }
 
 variable roles {


### PR DESCRIPTION
Add google service account module and use it in the command-center and environments/terraform/gcs; applied it, didn't get any errors, did a bunch of `terraform mv` commands to try to not break things. I'm mostly concerned about my updates to the init bash script, so please take a close look at those changes!