### PR TITLE
DSPDC-704 DSPDC-729 Write kubeconfigs to Vault and read them in scripts.

### DIFF
--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -14,10 +14,10 @@ module clinvar {
   is_production = false
   region = "us-central1"
   k8s_zone = "a"
-  kubeconfig_path = "${local.processing_kubeconfig_dir}/clinvar"
   k8s_scaled_cluster_max_size = 3
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
   reader_groups = ["clingendevs@broadinstitute.org"]
   deletion_age_days = null # FIXME: Reset back to 30 after we set up prod.
+  vault_prefix = "${local.vault_prefix}/processing-projects/clinvar"
 }

--- a/environments/dev/terraform/command-center.tf
+++ b/environments/dev/terraform/command-center.tf
@@ -22,7 +22,6 @@ module command_center {
   dns_zone_name = "monster-dev"
   k8s_cluster_size = 2
   k8s_machine_type = "n1-standard-2"
-  kubeconfig_path = "${var.kubeconfig_dir_path}/command-center"
   # 4 CPU, 15 GiB of RAM.
   db_tier = "db-custom-4-15360"
   vault_prefix = "${local.vault_prefix}/command-center"

--- a/hack/README.md
+++ b/hack/README.md
@@ -6,6 +6,7 @@ significantly different speeds (i.e. Terraform modules vs. Helm releases).
 ## Setting up a fresh environment
 If nothing's been set up yet, run the scripts in this order:
 1. `apply-terraform <env>`
+2. `init-cluster-resources <env>`
 2. `init-environment.sh <env>` # Will be broken down further in following PRs
 
 ## Why are there no teardown scripts?

--- a/hack/init-cluster-resources
+++ b/hack/init-cluster-resources
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
+declare -r REPO_ROOT=$(cd $(dirname ${SCRIPT_DIR}) >/dev/null 2>&1 && pwd)
+
+declare -r KUBECTL=achlanevenson/k8s-kubectl:v1.14.10
+
+declare -r HELM_OPERATOR_VERSION=v1.0.0-rc8
+declare -r SECRETS_MANAGER_VERSION=release-1.0.2
+
+declare -ra COMMAND_CENTER_BASE_NAMESPACES=(
+  fluxcd
+  secrets-manager
+  cloudsql-proxy
+  argo-ui
+  airflow
+)
+declare -ra PROCESSING_NAMESPACES=(
+  fluxcd
+  secrets-manager
+  argo
+)
+declare -ra CRDS=(
+  https://raw.githubusercontent.com/fluxcd/helm-operator/${HELM_OPERATOR_VERSION}/deploy/flux-helm-release-crd.yaml
+  https://raw.githubusercontent.com/tuenti/secrets-manager/${SECRETS_MANAGER_VERSION}/config/crd/bases/secrets-manager.tuenti.io_secretdefinitions.yaml
+)
+
+#####
+## Get names for the processing projects registered in the environment.
+##
+## Functions like this are why the directory is named 'hack'. Assumes that
+## all processing-project clusters in the environment have information stored
+## in Vault under a common prefix, and that the names of the directories found
+## immediately under that prefix are meant to represent project names.
+#####
+function get_processing_names () {
+  local -r env=$1
+  local -r vault_prefix=secret/dsde/monster/${env}/processing-projects/
+
+  declare -ra project_names=($(vault list ${vault_prefix} | grep '/' | sed 's#/##g'))
+  echo ${project_names[@]}
+}
+
+#####
+## Read the kubeconfig for a command-center GKE cluster from its expected
+## Vault path for the target environment.
+#####
+function get_command_center_config () {
+  local -r env=$1 config_target=$2
+
+  vault read -field=kubeconfig secret/dsde/monster/${env}/command-center/gke > ${config_target}
+}
+
+#####
+## Read the kubeconfig for a processing GKE cluster from its expected
+## Vault path for the target environment.
+#####
+function get_processing_config () {
+  local -r env=$1 project=$2 config_target=$3
+
+  vault read -field=kubeconfig secret/dsde/monster/${env}/processing-projects/${project}/gke > ${config_target}
+}
+
+#####
+## Initialize namespaces in a GKE cluster so we can
+## deploy into it.
+##
+## Helm used to create namespaces automatically but
+## dropped the behavior in v3 to be consistent with
+## kubectl. It's probably better to be explicit anyway.
+#####
+function install_namespaces () {
+  local -r kubeconfig=$1
+  shift
+  local -ra namespaces=${@}
+
+  declare -ra kubectl=(
+    docker run
+    # NOTE: `-t` omitted here on purpose because it's incompatible
+    # with `-a stdin`.
+    --rm -i
+    # Read from stdin so we can pipe in YAML.
+    -a stdin -a stdout -a stderr
+    # Configure the client to point at the cluster.
+    -v ${kubeconfig}:/root/.kube/config:ro
+    # Make sure it can auth with GKE.
+    -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro
+    ${KUBECTL}
+  )
+
+  for ns in ${namespaces[@]}; do
+    # kubectl apply a HEREDOC containing YAML for each namespace.
+    #
+    # It'd be simpler if we could just `kubectl create namespace ${ns}`.
+    # We can't do that because `create` fails when there's already a
+    # namespace with the given name. `apply` is idempotent, but it
+    # only accepts YAML / JSON as input -_-
+    ${kubectl[@]} apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${ns}
+EOF
+  done
+}
+
+#####
+## Initialize CRD APIs in a GKE cluster so we can push custom
+## resources into it.
+##
+## Helm used to allow deploying CRD APIs like any other resource,
+## but it changed the behavior in v3 to 1) remove templating of
+## CRDs and 2) only install CRDs, and never update them. Explicit
+## control of the APIs is probably better anyways, since updating
+## them in the wrong way can cause all existing objects of the kind
+## to be wiped out.
+#####
+function install_crds () {
+  local -r kubeconfig=$1
+  shift
+  local -ra crd_urls=${@}
+
+  declare -ra kubectl=(
+    docker run
+    --rm -it
+    # Configure the client to point at the cluster.
+    -v ${kubeconfig}:/root/.kube/config:ro
+    # Make sure it can auth with GKE.
+    -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro
+    ${KUBECTL}
+  )
+
+  for crd_url in ${crd_urls[@]}; do
+    ${kubectl[@]} apply -f ${crd_url}
+  done
+}
+
+#####
+## Entrypoint to the script.
+##
+## Ensures expected namespaces and CRDs are registered in the
+## command-center and processing clusters within a core Monster
+## environment.
+#####
+function main () {
+  # Check args.
+  if [ $# -ne 1 ]; then
+    1>&2 echo Usage: ${0} '<env>'
+    exit 1
+  fi
+
+  # Make sure config exists.
+  local -r env=$1
+  local -r env_dir=${REPO_ROOT}/environments/$env
+  if [ ! -d ${env_dir} ]; then
+    1>&2 echo Error: Invalid environment "'$1'"
+    exit 1
+  fi
+
+  local -r config_dir=${env_dir}/.kubeconfig
+  local -r processing_config_dir=${config_dir}/processing
+  rm -rf ${config_dir}
+  mkdir -p ${processing_config_dir}
+
+  # Pull the names of expected processing projects from Vault.
+  local -ra project_names=($(get_processing_names ${env}))
+
+  # Set up the command center for the environment.
+  local -ra all_command_center_namespaces=(${COMMAND_CENTER_BASE_NAMESPACES[@]} ${project_names[@]})
+  local -r center_config=${config_dir}/command-center
+
+  get_command_center_config ${env} ${center_config}
+  install_namespaces ${center_config} ${all_command_center_namespaces[@]}
+  install_crds ${center_config} ${CRDS[@]}
+
+  # Set up each processing project.
+  for project in ${project_names[@]}; do
+    local -r project_config=${processing_config_dir}/${project}
+
+    get_processing_config ${env} ${project} ${project_config}
+    install_namespaces ${project_config} ${PROCESSING_NAMESPACES[@]}
+    install_crds ${project_config} ${CRDS[@]}
+  done
+}
+
+main ${@}

--- a/hack/init-cluster-resources
+++ b/hack/init-cluster-resources
@@ -4,7 +4,7 @@ set -euo pipefail
 declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 declare -r REPO_ROOT=$(cd $(dirname ${SCRIPT_DIR}) >/dev/null 2>&1 && pwd)
 
-declare -r KUBECTL=achlanevenson/k8s-kubectl:v1.14.10
+declare -r KUBECTL=lachlanevenson/k8s-kubectl:v1.14.10
 
 declare -r HELM_OPERATOR_VERSION=v1.0.0-rc8
 declare -r SECRETS_MANAGER_VERSION=release-1.0.2

--- a/hack/init-environment.sh
+++ b/hack/init-environment.sh
@@ -8,89 +8,12 @@ declare -r REPO_ROOT=$(cd $(dirname ${SCRIPT_DIR}) >/dev/null 2>&1 && pwd)
 # The values don't matter as long as they're not empty.
 declare -rA ENVS=([dev]=valid)
 
-declare -ra COMMAND_CENTER_NAMESPACES=(
-  fluxcd
-  airflow
-  argo-ui
-  clinvar
-  encode
-  dog-aging
-  cloudsql-proxy
-  secrets-manager
-)
-declare -ra PROCESSING_NAMESPACES=(
-  argo
-  secrets-manager
-)
-
-declare -r KUBECTL=lachlanevenson/k8s-kubectl:v1.14.10
 declare -r HELM=lachlanevenson/k8s-helm:v3.0.2
 
-declare -r HELM_OPERATOR_VERSION=v1.0.0-rc5
 declare -r HELM_OPERATOR_CHART_VERSION=0.4.0
-declare -r SECRETS_MANAGER_VERSION=release-1.0.2
 declare -r SECRETS_MANAGER_CHART_VERSION=0.0.4
 
 declare -r KUBECONFIG_DIR_NAME=.kubeconfig
-
-
-#####
-## Initialize namespaces in a GKE cluster so we can
-## deploy into it.
-##
-## Helm used to create namespaces automatically but
-## dropped the behavior in v3 to be consistent with
-## kubectl. It's probably better to be explicit anyway.
-#####
-function create_namespaces () {
-  local -r kubeconfig=$1
-  shift
-  local -ra namespaces=${@}
-
-  declare -ra kubectl=(
-    docker run
-    # NOTE: `-t` omitted here on purpose because it's incompatible
-    # with `-a stdin`.
-    --rm -i
-    # Read from stdin so we can pipe in YAML.
-    -a stdin -a stdout -a stderr
-    # Configure the client to point at the cluster.
-    -v ${kubeconfig}:/root/.kube/config:ro
-    # Make sure it can auth with GKE.
-    -v ${HOME}/.config:/root/.config
-    ${KUBECTL}
-  )
-
-  for ns in ${namespaces[@]}; do
-    # kubectl apply a HEREDOC containing YAML for each namespace.
-    #
-    # It'd be simpler if we could just `kubectl create namespace ${ns}`.
-    # We can't do that because `create` fails when there's already a
-    # namespace with the given name. `apply` is idempotent, but it
-    # only accepts YAML / JSON as input -_-
-    ${kubectl[@]} apply -f - <<EOF
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ${ns}
-EOF
-  done
-}
-
-#####
-## Configure Kubernetes in Docker
-####
-function configure_kubernetes () {
-  local -r kubeconfig=$1
-
-  declare -ra kubernetes=(
-      docker run --rm -it \
-      -v ${kubeconfig}:/root/.kube/config:ro \
-      -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
-      ${KUBECTL}
-    )
-    echo ${kubernetes[@]}
-}
 
 #####
 ## Configure Helm in Docker
@@ -114,20 +37,11 @@ function configure_helm () {
   echo ${helm[@]}
 }
 
-
 #####
 ## Set up Flux CD's Helm Operator to manage deployments in GKE.
 #####
 function install_flux () {
   local -r kubeconfig=$1 env_dir=$2
-
-  # Install the CRD definitions separately. Helm doesn't have
-  # a coherent story for handling these yet (since updating them
-  # the wrong way can result in all existing objects being deleted),
-  # so they're easier to handle out-of-band.
-  declare -ra kubernetes=($(configure_kubernetes ${kubeconfig}))
-  ${kubernetes[@]} apply -f \
-    https://raw.githubusercontent.com/fluxcd/helm-operator/${HELM_OPERATOR_VERSION}/deploy/flux-helm-release-crd.yaml
 
   # Install the Operator using Helm.
   declare -ra helm=($(configure_helm ${kubeconfig} ${env_dir}))
@@ -152,13 +66,6 @@ function install_secrets_manager () {
   # vault location
   local -r vault_location=secret/dsde/monster/${env}/approle-monster-${env}
 
-  # Install the CRD definitions separately. Helm doesn't have
-  # a coherent story for handling these yet (since updating them
-  # the wrong way can result in all existing objects being deleted),
-  # so they're easier to handle out-of-band.
-  declare -ra kubernetes=($(configure_kubernetes ${kubeconfig}))
-  ${kubernetes[@]} apply -f \
-    https://raw.githubusercontent.com/tuenti/secrets-manager/${SECRETS_MANAGER_VERSION}/config/crd/bases/secrets-manager.tuenti.io_secretdefinitions.yaml
   # Install the Operator using Helm.
   declare -ra helm=($(configure_helm ${kubeconfig} ${env_dir}))
   rm -rf ${env_dir}/.helm
@@ -178,7 +85,6 @@ function install_secrets_manager () {
     --set="secretsgeneric.roleId=$(vault read -field=role_id $vault_location)" \
     --set="secretsgeneric.secretId=$(vault read -field=secret_id $vault_location)"
 }
-
 
 #####
 ## Set up Google's CloudSQL Proxy to communicate with the CloudSQL database.
@@ -220,19 +126,6 @@ function install_cloudsql_proxy () {
     --set existingSecretKey=cloudsqlkey.json
 }
 
-
-#####
-## Install Flux HelmRelease CRDs for all the software we want to
-## have running in the command-center GKE cluster.
-##
-## The Helm Operator will monitor the git repo specified in each
-## CRD and re-deploy whenever the target ref changes.
-#####
-function install_charts () {
-  1>&2 echo TODO
-}
-
-
 #####
 ## Script entrypoint.
 #####
@@ -259,15 +152,12 @@ function main () {
   local -r processing_configs_dir=${kubeconfig_dir}/processing
 
   # Initialize command-center GKE and services.
-  create_namespaces ${command_center_config} ${COMMAND_CENTER_NAMESPACES[@]}
   install_flux ${command_center_config} ${env_dir}
   install_secrets_manager ${command_center_config} ${env_dir} ${env}
   install_cloudsql_proxy ${command_center_config} ${env_dir} ${env}
-  install_charts
 
   # Initialize processing GKEs and services.
   for kubeconfig in ${processing_configs_dir}/*; do
-    create_namespaces ${kubeconfig} ${PROCESSING_NAMESPACES[@]}
     install_secrets_manager ${kubeconfig} ${env_dir} ${env}
   done
 }

--- a/templates/terraform/command-center-project/k8s.tf
+++ b/templates/terraform/command-center-project/k8s.tf
@@ -12,7 +12,10 @@ module master {
 
   network = module.k8s_network.network_link
   subnetwork = module.k8s_network.subnet_links[0]
+
+  vault_path = "${var.vault_prefix}/gke"
 }
+
 module node_pool {
   source = "/templates/k8s-node-pool"
   providers = {
@@ -30,11 +33,4 @@ module node_pool {
 
   autoscaling = null
   taints = null
-}
-
-# Write a kubeconfig for the cluster to disk, for use downstream.
-# Inspired by https://ahmet.im/blog/authenticating-to-gke-without-gcloud/
-resource local_file kubeconfig {
-  filename = var.kubeconfig_path
-  content = module.master.kubeconfig
 }

--- a/templates/terraform/command-center-project/variables.tf
+++ b/templates/terraform/command-center-project/variables.tf
@@ -18,11 +18,6 @@ variable k8s_machine_type {
   description = "Machine type to use in the GKE cluster."
 }
 
-variable kubeconfig_path {
-  type = string
-  description = "Local path where kubeconfig for the GKE cluster should be written."
-}
-
 variable db_tier {
   type = string
   description = "Machine tier for the Cloud SQL proxy instance backing command-center services."

--- a/templates/terraform/k8s-master/outputs.tf
+++ b/templates/terraform/k8s-master/outputs.tf
@@ -1,18 +1,3 @@
 output name {
   value = google_container_cluster.master.name
 }
-
-output kubeconfig {
-  value = <<EOF
-apiVersion: v1
-kind: Config
-current-context: context
-contexts: [{name: context, context: {cluster: ${google_container_cluster.master.name}, user: local-user}}]
-users: [{name: local-user, user: {auth-provider: {name: gcp}}}]
-clusters:
-- name: ${google_container_cluster.master.name}
-  cluster:
-    server: "https://${google_container_cluster.master.endpoint}"
-    certificate-authority-data: "${google_container_cluster.master.master_auth[0].cluster_ca_certificate}"
-EOF
-}

--- a/templates/terraform/k8s-master/variables.tf
+++ b/templates/terraform/k8s-master/variables.tf
@@ -21,3 +21,8 @@ variable network {
 variable subnetwork {
   type = string
 }
+
+variable vault_path {
+  type = string
+  description = "Path in Vault where secrets for the master should be stored."
+}

--- a/templates/terraform/processing-project/k8s-master.tf
+++ b/templates/terraform/processing-project/k8s-master.tf
@@ -12,6 +12,8 @@ module processing_k8s_master {
 
   network = module.k8s_network.network_link
   subnetwork = module.k8s_network.subnet_links[0]
+
+  vault_path = "${var.vault_prefix}/gke"
 }
 
 module processing_k8s_static_node_pool {
@@ -58,11 +60,4 @@ module processing_k8s_scaled_node_pool {
     value = "argo_autoscaling"
     effect = "NO_EXECUTE"
   }]
-}
-
-# Write a kubeconfig for the cluster to disk, for use downstream.
-# Inspired by https://ahmet.im/blog/authenticating-to-gke-without-gcloud/
-resource local_file processing_kubeconfig {
-  filename = var.kubeconfig_path
-  content = module.processing_k8s_master.kubeconfig
 }

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -33,11 +33,6 @@ variable k8s_zone {
   description = "Zone within `region` where GKE clusters should run"
 }
 
-variable kubeconfig_path {
-  type = string
-  description = "Local path where kubeconfig for the processing GKE cluster should be written."
-}
-
 variable reader_groups {
   type = list(string)
   description = "Email addresses that represent google groups to share bucket read access with."
@@ -46,4 +41,9 @@ variable reader_groups {
 variable deletion_age_days {
   type = number
   description = "The number of days to wait before deleting files in the staging bucket."
+}
+
+variable vault_prefix {
+  type = string
+  description = "Path prefix for secrets written to Vault."
 }


### PR DESCRIPTION
Instead of writing kubeconfigs to local disk, we write them to Vault. The hack scripts then need to read the configs from Vault to deploy things. Since my other two in-flight tickets involve re-writing / splitting most of `init-environment.sh`, I stuck the demo of "reading configs from Vault" in a new script which should be pretty stable.

Putting this out there as a draft because I haven't tried running it yet. Will wait for the dust to settle on the other in-flight TF tickets.