### PR TITLE
Add processing project service account to run GKE pods

### DIFF
--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -1,0 +1,11 @@
+module processing_gke_runner_account {
+  source = "/templates/google-sa"
+  providers = {
+    google.target = google.target
+  }
+
+  account_id = "processing-gke-runner"
+  display_name = "Service account to run GKE system pods"
+  vault_path = "${var.vault_prefix}/service-accounts/gke-runner"
+  roles = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
+}


### PR DESCRIPTION
Creating a service account to run GKE system pods for processing projects.

Note: These changes are pretty similar to those in [a previous PR ](https://github.com/broadinstitute/monster-deploy/pull/20/files) which created a similar service account for the command center.