### PR TITLE
Ra dspdc 699 dataflow runner

### DIFF
--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -8,6 +8,7 @@ module clinvar {
   source = "/templates/processing-project"
   providers = {
     google.target = google-beta.clinvar
+    vault.target = vault.command-center
   }
 
   project_name = "broad-dsp-monster-clingen-dev"

--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -7,7 +7,7 @@ provider google-beta {
 module clinvar {
   source = "/templates/processing-project"
   providers = {
-    google.target = google-beta.clinvar
+    google.target = google-beta.clinvar,
     vault.target = vault.command-center
   }
 

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -8,7 +8,7 @@ resource google_storage_bucket monster_test_bucket {
 module test_sa {
   source = "/templates/google-sa"
   providers = {
-    google.target = google-beta.command-center
+    google.target = google-beta.command-center,
     vault.target = vault.command-center
   }
 

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -9,6 +9,7 @@ module test_sa {
   source = "/templates/google-sa"
   providers = {
     google.target = google-beta.command-center
+    vault.target = vault.command-center
   }
 
   account_id = "monster-dev-test-sa"

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -2,6 +2,7 @@ module command_center_gke_runner_account {
   source = "/templates/google-sa"
   providers = {
     google.target = google.target
+    vault.target = vault.target
   }
 
   account_id = "command-center-gke-runner"

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -1,7 +1,7 @@
 module command_center_gke_runner_account {
   source = "/templates/google-sa"
   providers = {
-    google.target = google.target
+    google.target = google.target,
     vault.target = vault.target
   }
 

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -23,6 +23,17 @@ resource google_storage_bucket temp_bucket {
   }
 }
 
+resource google_storage_bucket_iam_member temp_bucket_iam {
+  provider = google.target
+  bucket = google_storage_bucket.temp_bucket.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role = "roles/storage.admin"
+  member = "serviceAccount:${module.dataflow_runner_account.email}"
+  depends_on = [module.dataflow_runner_account.delay]
+}
+
 # Bucket for temporary data storage.
 resource google_storage_bucket staging_storage {
   provider = google.target
@@ -40,6 +51,17 @@ resource google_storage_bucket staging_storage {
       }
     }
   }
+}
+
+resource google_storage_bucket_iam_member staging_bucket_iam {
+  provider = google.target
+  bucket = google_storage_bucket.temp_bucket.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role = "roles/storage.admin"
+  member = "serviceAccount:${module.dataflow_runner_account.email}"
+  depends_on = [module.dataflow_runner_account.delay]
 }
 
 resource google_storage_bucket_iam_member staging_iam_reader {

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -11,9 +11,9 @@ resource google_storage_bucket_iam_member artifact_bucket_uploader_iam {
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.legacyBucketWriter"
-  member = "serviceAccount:${module.dataflow_runner_account.email}"
-  depends_on = [module.dataflow_runner_account.delay]
+  role = "roles/storage.admin"
+  member = "serviceAccount:${module.artifact_uploader_account.email}"
+  depends_on = [module.artifact_uploader_account.delay]
 }
 
 # Bucket for temp files used by processing programs.

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -23,7 +23,7 @@ resource google_storage_bucket temp_bucket {
   }
 }
 
-resource google_storage_bucket_iam_member temp_bucket_iam {
+resource google_storage_bucket_iam_member temp_bucket_runner_iam {
   provider = google.target
   bucket = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
@@ -32,6 +32,17 @@ resource google_storage_bucket_iam_member temp_bucket_iam {
   role = "roles/storage.admin"
   member = "serviceAccount:${module.dataflow_runner_account.email}"
   depends_on = [module.dataflow_runner_account.delay]
+}
+
+resource google_storage_bucket_iam_member temp_bucket_launcher_iam {
+  provider = google.target
+  bucket = google_storage_bucket.temp_bucket.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role = "roles/storage.admin"
+  member = "serviceAccount:${module.dataflow_launcher_account.email}"
+  depends_on = [module.dataflow_launcher_account.delay]
 }
 
 # Bucket for temporary data storage.
@@ -53,7 +64,7 @@ resource google_storage_bucket staging_storage {
   }
 }
 
-resource google_storage_bucket_iam_member staging_bucket_iam {
+resource google_storage_bucket_iam_member staging_bucket_runner_iam {
   provider = google.target
   bucket = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -11,7 +11,7 @@ resource google_storage_bucket_iam_member artifact_bucket_uploader_iam {
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role = "roles/storage.legacyBucketWriter"
   member = "serviceAccount:${module.dataflow_runner_account.email}"
   depends_on = [module.dataflow_runner_account.delay]
 }

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -5,6 +5,17 @@ resource google_storage_bucket artifact_bucket {
   location = "US"
 }
 
+resource google_storage_bucket_iam_member artifact_bucket_uploader_iam {
+  provider = google.target
+  bucket = google_storage_bucket.artifact_bucket.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role = "roles/storage.admin"
+  member = "serviceAccount:${module.dataflow_runner_account.email}"
+  depends_on = [module.dataflow_runner_account.delay]
+}
+
 # Bucket for temp files used by processing programs.
 resource google_storage_bucket temp_bucket {
   provider = google.target

--- a/templates/terraform/processing-project/provider.tf
+++ b/templates/terraform/processing-project/provider.tf
@@ -1,3 +1,7 @@
 provider google {
   alias = "target"
 }
+
+provider vault {
+  alias = "target"
+}

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -34,14 +34,14 @@ module dataflow_launcher_account {
   roles = ["dataflow.developer", "compute.viewer"]
 }
 
-module dataflow_uploader_account {
+module artifact_uploader_account {
   source = "/templates/google-sa"
   providers = {
     google.target = google.target
   }
 
-  account_id = "dataflow-uploader"
-  display_name = " Service account to upload Dataflow artifacts to GCS"
-  vault_path = "${var.vault_prefix}/service-accounts/dataflow-uploader"
+  account_id = "artifact-uploader"
+  display_name = " Service account to upload artifacts to GCS"
+  vault_path = "${var.vault_prefix}/service-accounts/artifact-uploader"
   roles = []
 }

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -1,7 +1,7 @@
 module processing_gke_runner_account {
   source = "/templates/google-sa"
   providers = {
-    google.target = google.target
+    google.target = google.target,
     vault.target = vault.target
   }
 
@@ -14,7 +14,7 @@ module processing_gke_runner_account {
 module dataflow_runner_account {
   source = "/templates/google-sa"
   providers = {
-    google.target = google.target
+    google.target = google.target,
     vault.target = vault.target
   }
 
@@ -27,7 +27,7 @@ module dataflow_runner_account {
 module dataflow_launcher_account {
   source = "/templates/google-sa"
   providers = {
-    google.target = google.target
+    google.target = google.target,
     vault.target = vault.target
   }
 
@@ -40,7 +40,7 @@ module dataflow_launcher_account {
 module artifact_uploader_account {
   source = "/templates/google-sa"
   providers = {
-    google.target = google.target
+    google.target = google.target,
     vault.target = vault.target
   }
 

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -16,7 +16,7 @@ module dataflow_runner_account {
     google.target = google.target
   }
 
-  account_id = "dataflow_runner"
+  account_id = "dataflow-runner"
   display_name = " Service account to run Dataflow jobs"
   vault_path = "${var.vault_prefix}/service-accounts/dataflow-runner"
   roles = ["dataflow.worker"]

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -9,3 +9,15 @@ module processing_gke_runner_account {
   vault_path = "${var.vault_prefix}/service-accounts/gke-runner"
   roles = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
 }
+
+module dataflow_runner_account {
+  source = "/templates/google-sa"
+  providers = {
+    google.target = google.target
+  }
+
+  account_id = "dataflow_runner"
+  display_name = " Service account to run Dataflow jobs"
+  vault_path = "${var.vault_prefix}/service-accounts/dataflow-runner"
+  roles = ["dataflow.worker"]
+}

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -2,6 +2,7 @@ module processing_gke_runner_account {
   source = "/templates/google-sa"
   providers = {
     google.target = google.target
+    vault.target = vault.target
   }
 
   account_id = "processing-gke-runner"
@@ -14,6 +15,7 @@ module dataflow_runner_account {
   source = "/templates/google-sa"
   providers = {
     google.target = google.target
+    vault.target = vault.target
   }
 
   account_id = "dataflow-runner"
@@ -26,6 +28,7 @@ module dataflow_launcher_account {
   source = "/templates/google-sa"
   providers = {
     google.target = google.target
+    vault.target = vault.target
   }
 
   account_id = "dataflow-launcher"
@@ -38,6 +41,7 @@ module artifact_uploader_account {
   source = "/templates/google-sa"
   providers = {
     google.target = google.target
+    vault.target = vault.target
   }
 
   account_id = "artifact-uploader"

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -33,3 +33,15 @@ module dataflow_launcher_account {
   vault_path = "${var.vault_prefix}/service-accounts/dataflow-launcher"
   roles = ["dataflow.developer", "compute.viewer"]
 }
+
+module dataflow_uploader_account {
+  source = "/templates/google-sa"
+  providers = {
+    google.target = google.target
+  }
+
+  account_id = "dataflow-uploader"
+  display_name = " Service account to upload Dataflow artifacts to GCS"
+  vault_path = "${var.vault_prefix}/service-accounts/dataflow-uploader"
+  roles = []
+}

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -21,3 +21,15 @@ module dataflow_runner_account {
   vault_path = "${var.vault_prefix}/service-accounts/dataflow-runner"
   roles = ["dataflow.worker"]
 }
+
+module dataflow_launcher_account {
+  source = "/templates/google-sa"
+  providers = {
+    google.target = google.target
+  }
+
+  account_id = "dataflow-launcher"
+  display_name = " Service account to launch Dataflow jobs"
+  vault_path = "${var.vault_prefix}/service-accounts/dataflow-launcher"
+  roles = ["dataflow.developer", "compute.viewer"]
+}


### PR DESCRIPTION
Add a service account to run dataflow jobs to the processing project module; add bucket permissions for the service account on the temp and staging buckets.

Add a service account to launch dataflow jobs; add bucket permissions for the service account on the temp bucket.

Add a service account to upload artifacts to GCS; add bucket permissions for the service account on the artifact bucket.