### PR TITLE
Add databases and users to command-center cloudsql instance

### DIFF
--- a/environments/dev/terraform/command-center.tf
+++ b/environments/dev/terraform/command-center.tf
@@ -25,4 +25,6 @@ module command_center {
   # 4 CPU, 15 GiB of RAM.
   db_tier = "db-custom-4-15360"
   vault_prefix = "${local.vault_prefix}/command-center"
+  cloudsql_db_names = ["argo", "airflow", "datarepo", "stairway"]
+  cloudsql_user_names = ["argo", "airflow", "datarepo"]
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -13,8 +13,8 @@ module cloudsql {
     role = "database"
     state = "active"
   }
-  db_names = ["argo", "airflow", "datarepo", "stairway"]
-  user_names = ["argo", "airflow", "datarepo"]
+  db_names = var.cloudsql_db_names
+  user_names = var.cloudsql_user_names
   vault_prefix = var.vault_prefix
   dependencies = module.enable_services
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -13,8 +13,8 @@ module cloudsql {
     role = "database"
     state = "active"
   }
-  db_names = []
-  user_names = []
+  db_names = ["argo", "airflow", "datarepo", "stairway"]
+  user_names = ["argo", "airflow", "datarepo"]
   vault_prefix = var.vault_prefix
   dependencies = module.enable_services
 }

--- a/templates/terraform/command-center-project/variables.tf
+++ b/templates/terraform/command-center-project/variables.tf
@@ -27,3 +27,13 @@ variable vault_prefix {
   type = string
   description = "Path prefix for secrets written to Vault."
 }
+
+variable cloudsql_db_names {
+  type = list(string)
+  description = "List of names of databases which should be added to CloudSQL."
+}
+
+variable cloudsql_user_names {
+  type = list(string)
+  description = "List of user names which should be added to CloudSQL."
+}


### PR DESCRIPTION
A small change to add databases and users to the command-center cloudsql instance ([Jira Ticket](https://broadinstitute.atlassian.net/browse/DSPDC-706)).

Databases:
- argo
- airflow
- datarepo
- stairway

Users:
- argo
- airflow
- datarepo