### PR TITLE
QH DSPDC-698 - Extending k8s-node-pool to take service account email input

### DIFF
--- a/templates/terraform/command-center-project/k8s.tf
+++ b/templates/terraform/command-center-project/k8s.tf
@@ -14,6 +14,7 @@ module master {
   subnetwork = module.k8s_network.subnet_links[0]
 
   vault_path = "${var.vault_prefix}/gke"
+  service_account_email = module.command_center_gke_runner_account.email
 }
 
 module node_pool {
@@ -33,4 +34,5 @@ module node_pool {
 
   autoscaling = null
   taints = null
+  service_account_email = module.command_center_gke_runner_account.email
 }

--- a/templates/terraform/command-center-project/k8s.tf
+++ b/templates/terraform/command-center-project/k8s.tf
@@ -14,7 +14,6 @@ module master {
   subnetwork = module.k8s_network.subnet_links[0]
 
   vault_path = "${var.vault_prefix}/gke"
-  service_account_email = module.command_center_gke_runner_account.email
 }
 
 module node_pool {

--- a/templates/terraform/k8s-master/variables.tf
+++ b/templates/terraform/k8s-master/variables.tf
@@ -26,3 +26,8 @@ variable vault_path {
   type = string
   description = "Path in Vault where secrets for the master should be stored."
 }
+
+variable service_account_email {
+  type = string
+  description = "The email address of the service account."
+}

--- a/templates/terraform/k8s-master/variables.tf
+++ b/templates/terraform/k8s-master/variables.tf
@@ -26,8 +26,3 @@ variable vault_path {
   type = string
   description = "Path in Vault where secrets for the master should be stored."
 }
-
-variable service_account_email {
-  type = string
-  description = "The email address of the service account."
-}

--- a/templates/terraform/k8s-node-pool/main.tf
+++ b/templates/terraform/k8s-node-pool/main.tf
@@ -31,6 +31,7 @@ resource google_container_node_pool pool {
     image_type = "COS"
     machine_type = var.machine_type
     disk_size_gb = var.disk_size_gb
+    service_account = var.service_account_email
 
     dynamic "taint" {
       for_each = var.taints == null ? [] : var.taints

--- a/templates/terraform/k8s-node-pool/variables.tf
+++ b/templates/terraform/k8s-node-pool/variables.tf
@@ -57,3 +57,8 @@ variable disk_size_gb {
   type = number
   description = "Size of disk to allocate for each node in the pool."
 }
+
+variable service_account_email {
+  type = string
+  description = "The email address of the service account."
+}

--- a/templates/terraform/k8s-node-pool/variables.tf
+++ b/templates/terraform/k8s-node-pool/variables.tf
@@ -60,5 +60,5 @@ variable disk_size_gb {
 
 variable service_account_email {
   type = string
-  description = "The email address of the service account."
+  description = "The email address of the IAM service account that will run system pods."
 }

--- a/templates/terraform/processing-project/k8s-master.tf
+++ b/templates/terraform/processing-project/k8s-master.tf
@@ -14,6 +14,7 @@ module processing_k8s_master {
   subnetwork = module.k8s_network.subnet_links[0]
 
   vault_path = "${var.vault_prefix}/gke"
+  service_account_email = module.processing_gke_runner_account.email
 }
 
 module processing_k8s_static_node_pool {
@@ -33,6 +34,7 @@ module processing_k8s_static_node_pool {
 
   autoscaling = null
   taints = null
+  service_account_email = module.processing_gke_runner_account.email
 }
 
 module processing_k8s_scaled_node_pool {
@@ -60,4 +62,5 @@ module processing_k8s_scaled_node_pool {
     value = "argo_autoscaling"
     effect = "NO_EXECUTE"
   }]
+  service_account_email = module.processing_gke_runner_account.email
 }

--- a/templates/terraform/processing-project/k8s-master.tf
+++ b/templates/terraform/processing-project/k8s-master.tf
@@ -14,7 +14,6 @@ module processing_k8s_master {
   subnetwork = module.k8s_network.subnet_links[0]
 
   vault_path = "${var.vault_prefix}/gke"
-  service_account_email = module.processing_gke_runner_account.email
 }
 
 module processing_k8s_static_node_pool {


### PR DESCRIPTION
-Added a required string param "service_account_email" to the /k8s-node-pool and /k8s-master variables.tf files
-Using the new parameter in the /k8s-node-pool main script to set the "service_account" param
-Updated /command-center-project/k8s.tf and /processing-project/k8s-master to pass the SA emails