### PR TITLE
Add email to list of bucket readers for Clinvar dev

### DIFF
--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -18,7 +18,8 @@ module clinvar {
   k8s_scaled_cluster_max_size = 3
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
-  reader_groups = ["clingendevs@broadinstitute.org", "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"]
+  reader_groups = ["clingendevs@broadinstitute.org"]
+  jade_repo_email = "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"
   deletion_age_days = null # FIXME: Reset back to 30 after we set up prod.
   vault_prefix = "${local.vault_prefix}/processing-projects/clinvar"
 }

--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -18,7 +18,7 @@ module clinvar {
   k8s_scaled_cluster_max_size = 3
   k8s_scaled_machine_type = "n1-standard-1"
   k8s_static_cluster_size = 2
-  reader_groups = ["clingendevs@broadinstitute.org"]
+  reader_groups = ["clingendevs@broadinstitute.org", "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"]
   deletion_age_days = null # FIXME: Reset back to 30 after we set up prod.
   vault_prefix = "${local.vault_prefix}/processing-projects/clinvar"
 }

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -97,3 +97,12 @@ resource google_storage_bucket_iam_member staging_iam_reader {
   role = "roles/storage.legacyBucketReader"
   member = "group:${each.value}"
 }
+
+resource google_storage_bucket_iam_member staging_account_iam_reader {
+  provider = google.target
+  bucket = google_storage_bucket.staging_storage.name
+  # The legacyBucketReader policy seems to be the correct role to have the equivalent of a "Bucket Reader" ACL,
+  # as noted here https://cloud.google.com/storage/docs/access-control/iam
+  role = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${var.jade_repo_email}"
+}

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -47,3 +47,8 @@ variable vault_prefix {
   type = string
   description = "Path prefix for secrets written to Vault."
 }
+
+variable jade_repo_email {
+  type = string
+  description = "Email for the service account running the Jade Repo."
+}


### PR DESCRIPTION
Adding an email (for the account running the Dev Test Repo) to the list of bucket readers for the clinvar dev environment.