### PR TITLE
add v2f service account and attach IAM for bucket

### DIFF
--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -27,10 +27,21 @@ module v2f_writer {
   roles = []
 }
 
+data google_project v2f_project {
+  provider = google-beta.v2f
+}
+
 resource google_storage_bucket_iam_member v2f_iam {
   provider = google-beta.v2f
   bucket = google_storage_bucket.v2f_results_bucket.name
   role = "roles/storage.objectCreator"
   member = "serviceAccount:${module.v2f_writer.email}"
   depends_on = [module.v2f_writer.delay]
+}
+
+resource google_service_account_iam_binding v2f_binding_iam {
+  service_account_id = module.v2f_writer.email
+  role = "roles/iam.workloadIdentityUser"
+
+  members = ["serviceAccount:${data.google_project.v2f_project.name}.svc.id.goog[v2f/argo-runner]"]
 }

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -4,8 +4,33 @@ provider google-beta {
   alias = "v2f"
 }
 
+provider vault {
+  alias = "v2f"
+}
+
 resource google_storage_bucket v2f_results_bucket {
   provider = google-beta.v2f
   name = "variant-to-function-result-sets"
   location = "US"
+}
+
+module v2f_writer {
+  source = "/templates/google-sa"
+  providers = {
+    google.target = google-beta.v2f,
+    vault.target = vault.v2f
+  }
+
+  account_id = "v2f-writer"
+  display_name = " Service account to write V2F data to GCS"
+  vault_path = "secret/dsde/monster/prod/v2f/service-accounts/bucket-writer"
+  roles = []
+}
+
+resource google_storage_bucket_iam_member v2f_iam {
+  provider = google-beta.v2f
+  bucket = google_storage_bucket.v2f_results_bucket.name
+  role = "roles/storage.objectCreator"
+  member = "serviceAccount:${module.v2f_writer.email}"
+  depends_on = [module.v2f_writer.delay]
 }

--- a/hack/apply-cluster-resources
+++ b/hack/apply-cluster-resources
@@ -12,7 +12,7 @@ declare -ra COMMAND_CENTER_BASE_NAMESPACES=(
   secrets-manager
   cloudsql-proxy
   argo-ui
-  airflow
+  v2f
 )
 declare -ra PROCESSING_NAMESPACES=(
   fluxcd

--- a/hack/apply-helm-releases
+++ b/hack/apply-helm-releases
@@ -53,7 +53,8 @@ function run_command_center_release () {
    --set "cloudsql.region=$(vault read -field=region ${sql_instance_secret})" \
    --set "crd-operators.secretManager.roleId=$(vault read -field=role_id ${bootstrap_secret})" \
    --set "crd-operators.secretManager.secretId=$(vault read -field=secret_id ${bootstrap_secret})" \
-   --set "argoNamespaces[0]=clinvar"
+   --set "argoNamespaces[0]=clinvar" \
+   --set "argoNamespaces[1]=v2f"
 }
 
 #####

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -10,3 +10,24 @@ module command_center_gke_runner_account {
   vault_path = "${local.vault_prefix}/service-accounts/gke-runner"
   roles = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
 }
+
+module v2f_writer {
+  source = "/templates/google-sa"
+  providers = {
+    google.target = google.target,
+    vault.target = vault.target
+  }
+
+  account_id = "v2f-writer"
+  display_name = " Service account to write V2F data to GCS"
+  vault_path = "${local.vault_prefix}/service-accounts/v2f-writer"
+  roles = []
+}
+
+resource google_storage_bucket_iam_member v2f_iam {
+  provider = google.target
+  bucket = "gs://variant-to-function-result-sets"
+  role = "roles/storage.objectCreator"
+  member = "serviceAccount:${module.v2f_writer.email}"
+  depends_on = [module.v2f_writer.delay]
+}

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -10,24 +10,3 @@ module command_center_gke_runner_account {
   vault_path = "${local.vault_prefix}/service-accounts/gke-runner"
   roles = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
 }
-
-module v2f_writer {
-  source = "/templates/google-sa"
-  providers = {
-    google.target = google.target,
-    vault.target = vault.target
-  }
-
-  account_id = "v2f-writer"
-  display_name = " Service account to write V2F data to GCS"
-  vault_path = "${local.vault_prefix}/service-accounts/v2f-writer"
-  roles = []
-}
-
-resource google_storage_bucket_iam_member v2f_iam {
-  provider = google.target
-  bucket = "gs://variant-to-function-result-sets"
-  role = "roles/storage.objectCreator"
-  member = "serviceAccount:${module.v2f_writer.email}"
-  depends_on = [module.v2f_writer.delay]
-}


### PR DESCRIPTION
I think this is p straightforward! I have hard coded the bucket to write to, I put it in the command-center's service accounts file because we're not spinning up a processing project for this, and I believe the objectCreator role is correct; those are the things I'd love to get double checked if anyone sees anything awry with 'em.