### PR TITLE
Sw dspdc 815 add bigquery to processing project

### DIFF
--- a/templates/terraform/processing-project/bigquery.tf
+++ b/templates/terraform/processing-project/bigquery.tf
@@ -2,16 +2,16 @@ resource google_bigquery_dataset dataset {
   provider = google.target
   dataset_id = "bigquery-dataset-dev"
   friendly_name = "BigQuery Dev Dataset"
-  description = "BigQuery dataset for the Jade Repo"
+  description = "BigQuery development dataset"
   location = "US"
   default_table_expiration_ms = 604800000 # 7 days
 
   access {
     role = "roles/bigquery.dataEditor"
-    user_by_email = var.jade_repo_email
+    user_by_email = var.command_center_argo_account_email
   }
   access {
     role = "roles/bigquery.jobUser"
-    user_by_email = var.jade_repo_email
+    user_by_email = var.command_center_argo_account_email
   }
 }

--- a/templates/terraform/processing-project/bigquery.tf
+++ b/templates/terraform/processing-project/bigquery.tf
@@ -1,0 +1,17 @@
+resource google_bigquery_dataset dataset {
+  provider = google.target
+  dataset_id = "bigquery-dataset-dev"
+  friendly_name = "BigQuery Dev Dataset"
+  description = "BigQuery dataset for the Jade Repo"
+  location = "US"
+  default_table_expiration_ms = 604800000 # 7 days
+
+  access {
+    role = "roles/bigquery.dataEditor"
+    user_by_email = var.jade_repo_email
+  }
+  access {
+    role = "roles/bigquery.jobUser"
+    user_by_email = var.jade_repo_email
+  }
+}

--- a/templates/terraform/processing-project/bigquery.tf
+++ b/templates/terraform/processing-project/bigquery.tf
@@ -1,8 +1,7 @@
 resource google_bigquery_dataset dataset {
   provider = google.target
-  dataset_id = "bigquery-dataset-dev"
-  friendly_name = "BigQuery Dev Dataset"
-  description = "BigQuery development dataset"
+  dataset_id = "monster_staging_data"
+  description = "Dataset used by the Monster team for ingest ETL"
   location = "US"
   default_table_expiration_ms = 604800000 # 7 days
 

--- a/templates/terraform/processing-project/services.tf
+++ b/templates/terraform/processing-project/services.tf
@@ -18,6 +18,7 @@ module enable_services {
     "runtimeconfig.googleapis.com",
     "stackdriver.googleapis.com",
     "storage-api.googleapis.com",
-    "storage-component.googleapis.com"
+    "storage-component.googleapis.com",
+    "bigquery.googleapis.com"
   ]
 }


### PR DESCRIPTION


Adding BigQuery to the processing project [(Jira Ticket) ](https://broadinstitute.atlassian.net/browse/DSPDC-815):
- Added to the list of APIs enabled
- Created a BigQuery dataset and assigned roles to the command center service account

The terraform output looks like:
```
  # module.clinvar.google_bigquery_dataset.dataset will be created
  + resource "google_bigquery_dataset" "dataset" {
      + creation_time               = (known after apply)
      + dataset_id                  = "bigquery-dataset-dev"
      + default_table_expiration_ms = 604800000
      + delete_contents_on_destroy  = false
      + description                 = "BigQuery development dataset"
      + etag                        = (known after apply)
      + friendly_name               = "BigQuery Dev Dataset"
      + id                          = (known after apply)
      + last_modified_time          = (known after apply)
      + location                    = "US"
      + project                     = (known after apply)
      + self_link                   = (known after apply)

      + access {
          + role          = "roles/bigquery.dataEditor"
          + user_by_email = "clinvar-argo-runner@broad-dsp-monster-dev.iam.gserviceaccount.com"
        }
      + access {
          + role          = "roles/bigquery.jobUser"
          + user_by_email = "clinvar-argo-runner@broad-dsp-monster-dev.iam.gserviceaccount.com"
        }
    }

  # module.clinvar.module.enable_services.google_project_service.services[15] will be created
  + resource "google_project_service" "services" {
      + disable_on_destroy = false
      + id                 = (known after apply)
      + project            = (known after apply)
      + service            = "bigquery.googleapis.com"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```