### PR TITLE
Bug fix: Roles for bigquery dataset

### DIFF
--- a/templates/terraform/processing-project/bigquery.tf
+++ b/templates/terraform/processing-project/bigquery.tf
@@ -9,8 +9,4 @@ resource google_bigquery_dataset dataset {
     role = "roles/bigquery.dataEditor"
     user_by_email = var.command_center_argo_account_email
   }
-  access {
-    role = "roles/bigquery.jobUser"
-    user_by_email = var.command_center_argo_account_email
-  }
 }

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -12,7 +12,7 @@ module dataflow_runner_account {
 }
 
 resource google_project_iam_member command_center_argo_account_iam {
-  for_each = toset(["dataflow.developer", "compute.viewer"])
+  for_each = toset(["dataflow.developer", "compute.viewer", "bigquery.jobUser"])
 
   provider = google.target
   role = "roles/${each.value}"


### PR DESCRIPTION
After #42 was merged, I tried to apply the terraform changes and got the following error because the role `bigquery.jobUser` was being applied at the wrong level:

```
Error: Error creating Dataset: googleapi: 
Error 400: IAM setPolicy failed for Dataset broad-dsp-monster-clingen-dev:monster_staging_data: Role roles/bigquery.jobUser is not supported for this resource.
```
This PR is to fix that issue by applying the role at the project level instead of the dataset level.