### PR TITLE
Add user as admin to v2f bucket

### DIFF
--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -59,3 +59,10 @@ resource google_storage_bucket_iam_member v2f_reader_iam {
   role = "roles/storage.objectViewer"
   member = "group:v2fcir@broadinstitute.org"
 }
+
+resource google_storage_bucket_iam_member v2f_admin_iam {
+  provider = google-beta.v2f
+  bucket = google_storage_bucket.v2f_results_bucket.name
+  role = "roles/storage.objectAdmin"
+  member = "user:schaluva@broadinstitute.org"
+}


### PR DESCRIPTION
[Jira Ticket](https://broadinstitute.atlassian.net/browse/DSPDC-886) 

Adding schaluva@broadinstitute.org as an admin to the v2f bucket.

Terraform output:
```
  # google_storage_bucket_iam_member.v2f_admin_iam will be created
  + resource "google_storage_bucket_iam_member" "v2f_admin_iam" {
      + bucket = "variant-to-function-result-sets"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "user:schaluva@broadinstitute.org"
      + role   = "roles/storage.objectAdmin"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```