### PR TITLE
DSPDC-731 Re-enable TTL on clinvar staging storage

### DIFF
--- a/environments/dev/terraform/clinvar.tf
+++ b/environments/dev/terraform/clinvar.tf
@@ -17,6 +17,6 @@ module clinvar {
   region = "us-central1"
   reader_groups = ["clingendevs@broadinstitute.org"]
   jade_repo_email = "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"
-  deletion_age_days = null # FIXME: Reset back to 30 after we set up prod.
+  deletion_age_days = 14
   vault_prefix = "${local.vault_prefix}/processing-projects/clinvar"
 }

--- a/templates/terraform/processing-project/bigquery.tf
+++ b/templates/terraform/processing-project/bigquery.tf
@@ -6,7 +6,19 @@ resource google_bigquery_dataset dataset {
   default_table_expiration_ms = 604800000 # 7 days
 
   access {
-    role = "roles/bigquery.dataEditor"
+    role = "OWNER"
+    special_group = "projectOwners"
+  }
+  access {
+    role = "EDITOR"
+    special_group = "projectWriters"
+  }
+  access {
+    role = "READER"
+    special_group = "projectReaders"
+  }
+  access {
+    role = "EDITOR"
     user_by_email = var.command_center_argo_account_email
   }
 }

--- a/templates/terraform/processing-project/bigquery.tf
+++ b/templates/terraform/processing-project/bigquery.tf
@@ -5,20 +5,25 @@ resource google_bigquery_dataset dataset {
   location = "US"
   default_table_expiration_ms = 604800000 # 7 days
 
+  # Apparently these aren't automatically applied.
+  # If we don't set the owner in particular, whoever happens to
+  # apply the TF will be automatically assigned OWNER permissions.
   access {
     role = "OWNER"
     special_group = "projectOwners"
   }
   access {
-    role = "EDITOR"
+    role = "WRITER"
     special_group = "projectWriters"
   }
   access {
     role = "READER"
     special_group = "projectReaders"
   }
+
+  # Make sure the processing SA can generate data.
   access {
-    role = "EDITOR"
+    role = "WRITER"
     user_by_email = var.command_center_argo_account_email
   }
 }


### PR DESCRIPTION
We'd managed to accumulate a few hundred-thousand files in the bucket from recent testing.

I also tweaked our BQ access controls here. When I was viewing the `plan` output for the bucket it showed that:
1. The BQ API rewrites non-primitive roles (i.e. `roles/bigquery.dataEditor`) to primitive roles (`WRITER`) when it can, so using the non-primitive role will always cause a TF diff.
2. If no explicit owner is marked in the access block, whoever applies the TF is automatically made an owner.