### PR TITLE
Bump FluxCD and Argo versions.

### DIFF
--- a/hack/apply-base-cluster-resources
+++ b/hack/apply-base-cluster-resources
@@ -4,11 +4,11 @@ set -euo pipefail
 declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 declare -r REPO_ROOT=$(cd $(dirname ${SCRIPT_DIR}) >/dev/null 2>&1 && pwd)
 
-declare -r HELM_OPERATOR_VERSION=v1.0.0-rc8
+declare -r HELM_OPERATOR_VERSION=1.0.0
 declare -r SECRETS_MANAGER_VERSION=release-1.0.2
 
 declare -ra CRDS=(
-  https://raw.githubusercontent.com/fluxcd/helm-operator/${HELM_OPERATOR_VERSION}/deploy/flux-helm-release-crd.yaml
+  https://raw.githubusercontent.com/fluxcd/helm-operator/v${HELM_OPERATOR_VERSION}/deploy/crds.yaml
   https://raw.githubusercontent.com/tuenti/secrets-manager/${SECRETS_MANAGER_VERSION}/config/crd/bases/secrets-manager.tuenti.io_secretdefinitions.yaml
 )
 
@@ -41,6 +41,7 @@ function install_base_operators () {
   ${helm[@]} upgrade base-crd-operators /charts/crd-operators \
     --namespace fluxcd \
     --install \
+    --set "helm-operator.image.tag=${HELM_OPERATOR_VERSION}" \
     --set "secretManager.roleId=$(vault read -field=role_id ${bootstrap_secret})" \
     --set "secretManager.secretId=$(vault read -field=secret_id ${bootstrap_secret})"
 }

--- a/templates/helm/command-center/templates/argo.yaml
+++ b/templates/helm/command-center/templates/argo.yaml
@@ -43,7 +43,7 @@ spec:
   chart:
     repository: https://broadinstitute.github.io/monster-helm
     name: argo-controller
-    version: 0.5.1
+    version: 0.5.2
   values:
     clusterName: command-center-cluster
     debug: {{ eq $env "dev" }}
@@ -84,7 +84,7 @@ spec:
   chart:
     repository: https://broadinstitute.github.io/monster-helm
     name: argo-server
-    version: 0.6.1
+    version: 0.6.2
   values:
     clusterName: command-center-cluster
     stackdriverProject: broad-dsp-monster-{{ .Values.env }}

--- a/templates/helm/crd-operators/Chart.yaml
+++ b/templates/helm/crd-operators/Chart.yaml
@@ -5,4 +5,4 @@ version: 0.1.0
 dependencies:
   - name: helm-operator
     repository: https://charts.fluxcd.io
-    version: 0.6.0
+    version: 0.7.0


### PR DESCRIPTION
Looks like flux moved some stuff around in their repo, but nothing broke on a test deploy.