### PR TITLE
Fix typos in encode orchestration workflow

### DIFF
--- a/hack/apply-orchestration-workflows
+++ b/hack/apply-orchestration-workflows
@@ -16,7 +16,7 @@ function install_orchestration_workflows () {
     --install \
     --set "env=${env}" \
     --set "clinvar.enable=true" \
-    --set 'clinvar.schedule="0 8 * * *"'
+    --set 'clinvar.schedule="0 8 * * *"' \
     --set "encode.enable=true" \
     --set 'encode.schedule="0 8 * * *"'
 }

--- a/templates/helm/orchestration-workflows/templates/encode.yaml
+++ b/templates/helm/orchestration-workflows/templates/encode.yaml
@@ -51,4 +51,4 @@ spec:
       subnetName: monster-processing-network
       workerAccount: dataflow-runner@{{ $project }}.iam.gserviceaccount.com
       useFlexRS: {{ eq .Values.env "prod" }}
-  {{- end }}
+{{- end }}

--- a/templates/helm/orchestration-workflows/values.schema.json
+++ b/templates/helm/orchestration-workflows/values.schema.json
@@ -6,15 +6,20 @@
     "clinvar": {
       "type": "object",
       "properties": {
+        "enable": {
+          "type": "boolean"
+        },
+        "schedule": {
+          "type": "string"
+        }
+      }
+    },
+    "encode": {
+      "type": "object",
+      "properties": {
         "enable": { "type": "boolean" },
         "schedule": { "type": "string" }
-      },
-      "encode": {
-        "type": "object",
-        "properties": {
-          "enable": { "type": "boolean" },
-          "schedule": { "type": "string" }
-        }
+      }
     }
   },
   "required": ["env"]


### PR DESCRIPTION
Fixing a couple of typos, to allow the encode orchestration workflow from https://github.com/broadinstitute/monster-deploy/pull/60 to execute.

I already ran this on dev with the new changes to make sure it works this time. 