### PR TITLE
add a bucket and iam role to the processing project module

### DIFF
--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -95,3 +95,20 @@ resource google_storage_bucket_iam_member staging_account_iam_reader {
   role = "roles/storage.objectViewer"
   member = "serviceAccount:${var.jade_repo_email}"
 }
+
+# Bucket for long term Argo logs storage, currently want no "delete after N days" rule.
+resource google_storage_bucket argo_logs_storage {
+  provider = google.target
+  name = "${var.project_name}-argo-logs-storage"
+  location = "US"
+}
+
+resource google_storage_bucket_iam_member command_center_argo_logs_bucket_iam {
+  provider = google.target
+  bucket =  google_storage_bucket.argo_logs_storage.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role = "roles/storage.admin"
+  member = "serviceAccount:${var.command_center_argo_account_email}"
+}

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -97,15 +97,15 @@ resource google_storage_bucket_iam_member staging_account_iam_reader {
 }
 
 # Bucket for long term Argo logs storage, currently want no "delete after N days" rule.
-resource google_storage_bucket argo_logs_storage {
+resource google_storage_bucket argo_archive {
   provider = google.target
-  name = "${var.project_name}-argo-logs-storage"
+  name = "${var.project_name}-argo-archive"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member command_center_argo_logs_bucket_iam {
   provider = google.target
-  bucket =  google_storage_bucket.argo_logs_storage.name
+  bucket =  google_storage_bucket.argo_archive.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles


### PR DESCRIPTION
^what the title says. This is for long term storage of argo logs. Here is the plan:
```
Terraform will perform the following actions:

  # module.monster_infrastructure.module.clinvar.google_storage_bucket.argo_logs_storage will be created
  + resource "google_storage_bucket" "argo_logs_storage" {
      + bucket_policy_only = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + location           = "US"
      + name               = "broad-dsp-monster-clingen-dev-argo-logs-storage"
      + project            = (known after apply)
      + self_link          = (known after apply)
      + storage_class      = "STANDARD"
      + url                = (known after apply)
    }

  # module.monster_infrastructure.module.clinvar.google_storage_bucket_iam_member.command_center_argo_logs_bucket_iam will be created
  + resource "google_storage_bucket_iam_member" "command_center_argo_logs_bucket_iam" {
      + bucket = "broad-dsp-monster-clingen-dev-argo-logs-storage"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "serviceAccount:clinvar-argo-runner@broad-dsp-monster-dev.iam.gserviceaccount.com"
      + role   = "roles/storage.admin"
    }

  # module.monster_infrastructure.module.encode.google_storage_bucket.argo_logs_storage will be created
  + resource "google_storage_bucket" "argo_logs_storage" {
      + bucket_policy_only = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + location           = "US"
      + name               = "broad-dsp-monster-encode-dev-argo-logs-storage"
      + project            = (known after apply)
      + self_link          = (known after apply)
      + storage_class      = "STANDARD"
      + url                = (known after apply)
    }

  # module.monster_infrastructure.module.encode.google_storage_bucket_iam_member.command_center_argo_logs_bucket_iam will be created
  + resource "google_storage_bucket_iam_member" "command_center_argo_logs_bucket_iam" {
      + bucket = "broad-dsp-monster-encode-dev-argo-logs-storage"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "serviceAccount:encode-argo-runner@broad-dsp-monster-dev.iam.gserviceaccount.com"
      + role   = "roles/storage.admin"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```