### PR TITLE
DSPDC-979 Add optional results bucket to processing-project module.

### DIFF
--- a/templates/terraform/monster-infrastructure/clinvar.tf
+++ b/templates/terraform/monster-infrastructure/clinvar.tf
@@ -9,7 +9,8 @@ module clinvar {
   is_production = var.is_production
   command_center_argo_account_email = module.command_center.clinvar_argo_runner_email
   region = "us-central1"
-  reader_groups = ["clingendevs@broadinstitute.org"]
+  create_results_bucket = true
+  result_reader_groups = ["clingendevs@broadinstitute.org"]
   jade_repo_email = local.jade_repo_email
   deletion_age_days = 14
   vault_prefix = "${local.vault_prefix}/processing-projects/clinvar"

--- a/templates/terraform/monster-infrastructure/encode.tf
+++ b/templates/terraform/monster-infrastructure/encode.tf
@@ -9,7 +9,6 @@ module encode {
   is_production = var.is_production
   command_center_argo_account_email = module.command_center.encode_argo_runner_email
   region = "us-west1"
-  reader_groups = []
   jade_repo_email = local.jade_repo_email
   deletion_age_days = 14
   vault_prefix = "${local.vault_prefix}/processing-projects/encode"

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -13,9 +13,16 @@ variable region {
   description = "Region where processing should run"
 }
 
-variable reader_groups {
+variable create_results_bucket {
+  type = bool
+  description = "If true, create a dedicated bucket for delivery of ingest outputs outside of the Data Repo."
+  default = false
+}
+
+variable result_reader_groups {
   type = list(string)
-  description = "Email addresses that represent google groups to share bucket read access with."
+  description = "Email addresses of google groups that should be able to read from the results bucket."
+  default = []
 }
 
 variable deletion_age_days {


### PR DESCRIPTION
Plan output is:
```
  # module.monster_infrastructure.module.clinvar.google_storage_bucket.results_storage[0] will be created
  + resource "google_storage_bucket" "results_storage" {
      + bucket_policy_only = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + location           = "US"
      + name               = "broad-dsp-monster-clingen-dev-ingest-results"
      + project            = (known after apply)
      + self_link          = (known after apply)
      + storage_class      = "STANDARD"
      + url                = (known after apply)
    }

  # module.monster_infrastructure.module.clinvar.google_storage_bucket_iam_member.results_external_readers["clingendevs@broadinstitute.org"] will be created
  + resource "google_storage_bucket_iam_member" "results_external_readers" {
      + bucket = "broad-dsp-monster-clingen-dev-ingest-results"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "group:clingendevs@broadinstitute.org"
      + role   = "roles/storage.objectViewer"
    }

  # module.monster_infrastructure.module.clinvar.google_storage_bucket_iam_member.results_writer[0] will be created
  + resource "google_storage_bucket_iam_member" "results_writer" {
      + bucket = "broad-dsp-monster-clingen-dev-ingest-results"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "serviceAccount:clinvar-argo-runner@broad-dsp-monster-dev.iam.gserviceaccount.com"
      + role   = "roles/storage.admin"
    }

  # module.monster_infrastructure.module.clinvar.google_storage_bucket_iam_member.staging_iam_reader["clingendevs@broadinstitute.org"] will be destroyed
  - resource "google_storage_bucket_iam_member" "staging_iam_reader" {
      - bucket = "broad-dsp-monster-clingen-dev-staging-storage" -> null
      - etag   = "CA0=" -> null
      - id     = "broad-dsp-monster-clingen-dev-staging-storage/roles/storage.objectViewer/group:clingendevs@broadinstitute.org" -> null
      - member = "group:clingendevs@broadinstitute.org" -> null
      - role   = "roles/storage.objectViewer" -> null
    }

Plan: 3 to add, 0 to change, 1 to destroy.
```