### PR TITLE
DSPDC-915 Generate AWS users for ENCODE.

### DIFF
--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -20,13 +20,19 @@ provider google-beta {
   alias = "encode"
 }
 
+provider aws {
+  region = "us-east-1"
+  alias = "encode"
+}
+
 module monster_infrastructure {
   source = "/templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center
     google.clinvar = google-beta.clinvar
-    google.encode = google-beta.encode
+    google.encode = google-beta.encode,
+    aws.encode = aws.encode
   }
 
   is_production = false

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -20,13 +20,19 @@ provider google-beta {
   alias = "encode"
 }
 
+provider aws {
+  region = "us-east-1"
+  alias = "encode"
+}
+
 module monster_infrastructure {
   source = "/templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center
     google.clinvar = google-beta.clinvar
-    google.encode = google-beta.encode
+    google.encode = google-beta.encode,
+    aws.encode = aws.encode
   }
 
   is_production = true

--- a/hack/apply-command-center-resources
+++ b/hack/apply-command-center-resources
@@ -49,7 +49,8 @@ function install_command_center_services () {
    --set "cloudsql.name=$(vault read -field=name ${sql_instance_secret})" \
    --set "cloudsql.project=$(vault read -field=project ${sql_instance_secret})" \
    --set "cloudsql.region=$(vault read -field=region ${sql_instance_secret})" \
-   --set "argoNamespaces[0]=clinvar"
+   --set "argoNamespaces[0]=clinvar" \
+   --set "argoNamespaces[1]=encode"
 }
 
 #####

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -5,7 +5,7 @@
 #####
 ## Constants.
 #####
-declare -r TERRAFORM=hashicorp/terraform:0.12.23
+declare -r TERRAFORM=hashicorp/terraform:0.12.24
 declare -r KUBECTL=lachlanevenson/k8s-kubectl:v1.14.10
 declare -r HELM=lachlanevenson/k8s-helm:v3.0.3
 

--- a/templates/terraform/aws-sa/README.md
+++ b/templates/terraform/aws-sa/README.md
@@ -1,0 +1,3 @@
+# AWS Service Account
+
+This module creates an AWS account. It creates a key associated with the account and writes it to Vault.

--- a/templates/terraform/aws-sa/main.tf
+++ b/templates/terraform/aws-sa/main.tf
@@ -1,0 +1,18 @@
+resource aws_iam_user user {
+  provider = aws.target
+  name = var.account_id
+}
+resource aws_iam_access_key user_key {
+  provider = aws.target
+  user = aws_iam_user.user.name
+}
+resource vault_generic_secret user_secret {
+  provider = vault.target
+  path = var.vault_path
+  data_json = <<DATA
+{
+  "access_key_id": "${aws_iam_access_key.user_key.id}",
+  "secret_access_key": "${aws_iam_access_key.user_key.secret}"
+}
+DATA
+}

--- a/templates/terraform/aws-sa/outputs.tf
+++ b/templates/terraform/aws-sa/outputs.tf
@@ -1,0 +1,3 @@
+output name {
+  value = aws_iam_user.user.name
+}

--- a/templates/terraform/aws-sa/provider.tf
+++ b/templates/terraform/aws-sa/provider.tf
@@ -1,0 +1,7 @@
+provider aws {
+  alias = "target"
+}
+
+provider vault {
+  alias = "target"
+}

--- a/templates/terraform/aws-sa/variables.tf
+++ b/templates/terraform/aws-sa/variables.tf
@@ -1,0 +1,9 @@
+variable account_id {
+  type = string
+  description = "Name to assign to the new account."
+}
+
+variable vault_path {
+  type = string
+  description = "Vault path where the new account's GCS key should be stored."
+}

--- a/templates/terraform/monster-infrastructure/encode.tf
+++ b/templates/terraform/monster-infrastructure/encode.tf
@@ -13,3 +13,13 @@ module encode {
   deletion_age_days = 14
   vault_prefix = "${local.vault_prefix}/processing-projects/encode"
 }
+
+module encode_s3_user {
+  source = "/templates/aws-sa"
+  providers = {
+    aws.target = aws.encode
+  }
+
+  account_id = "monster-${local.env}-encode-downloader"
+  vault_path = "${local.vault_prefix}/processing-projects/encode/s3-downloader"
+}

--- a/templates/terraform/monster-infrastructure/provider.tf
+++ b/templates/terraform/monster-infrastructure/provider.tf
@@ -13,3 +13,7 @@ provider google {
 provider google {
   alias = "encode"
 }
+
+provider aws {
+  alias = "encode"
+}


### PR DESCRIPTION
Plan output is:
```
Terraform will perform the following actions:

  # aws_iam_access_key.s3_transfer_user_key will be destroyed
  - resource "aws_iam_access_key" "s3_transfer_user_key" {
      - id                = "AKIA53RL2ZNQGEJAS2GD" -> null
      - secret            = (sensitive value)
      - ses_smtp_password = (sensitive value)
      - status            = "Active" -> null
      - user              = "monster-s3-tester" -> null
    }

  # aws_iam_user.s3_transfer_user will be destroyed
  - resource "aws_iam_user" "s3_transfer_user" {
      - arn           = "arn:aws:iam::952500931424:user/monster-s3-tester" -> null
      - force_destroy = false -> null
      - id            = "monster-s3-tester" -> null
      - name          = "monster-s3-tester" -> null
      - path          = "/" -> null
      - tags          = {} -> null
      - unique_id     = "AIDA53RL2ZNQGN3WIIHSL" -> null
    }

  # vault_generic_secret.s3_transfer_user_secret will be destroyed
  - resource "vault_generic_secret" "s3_transfer_user_secret" {
      - data         = (sensitive value)
      - data_json    = (sensitive value)
      - disable_read = false -> null
      - id           = "secret/dsde/monster/dev/aws/s3-transfer-user" -> null
      - path         = "secret/dsde/monster/dev/aws/s3-transfer-user" -> null
    }

  # module.test_transfer_user.aws_iam_access_key.user_key will be created
  + resource "aws_iam_access_key" "user_key" {
      + encrypted_secret  = (known after apply)
      + id                = (known after apply)
      + key_fingerprint   = (known after apply)
      + secret            = (sensitive value)
      + ses_smtp_password = (sensitive value)
      + status            = (known after apply)
      + user              = "monster-s3-tester"
    }

  # module.test_transfer_user.aws_iam_user.user will be created
  + resource "aws_iam_user" "user" {
      + arn           = (known after apply)
      + force_destroy = false
      + id            = (known after apply)
      + name          = "monster-s3-tester"
      + path          = "/"
      + unique_id     = (known after apply)
    }

  # module.test_transfer_user.vault_generic_secret.user_secret will be created
  + resource "vault_generic_secret" "user_secret" {
      + data         = (sensitive value)
      + data_json    = (sensitive value)
      + disable_read = false
      + id           = (known after apply)
      + path         = "secret/dsde/monster/dev/aws/s3-transfer-user"
    }

  # module.monster_infrastructure.module.encode_s3_user.aws_iam_access_key.user_key will be created
  + resource "aws_iam_access_key" "user_key" {
      + encrypted_secret  = (known after apply)
      + id                = (known after apply)
      + key_fingerprint   = (known after apply)
      + secret            = (sensitive value)
      + ses_smtp_password = (sensitive value)
      + status            = (known after apply)
      + user              = "monster-dev-encode-downloader"
    }

  # module.monster_infrastructure.module.encode_s3_user.aws_iam_user.user will be created
  + resource "aws_iam_user" "user" {
      + arn           = (known after apply)
      + force_destroy = false
      + id            = (known after apply)
      + name          = "monster-dev-encode-downloader"
      + path          = "/"
      + unique_id     = (known after apply)
    }

  # module.monster_infrastructure.module.encode_s3_user.vault_generic_secret.user_secret will be created
  + resource "vault_generic_secret" "user_secret" {
      + data         = (sensitive value)
      + data_json    = (sensitive value)
      + disable_read = false
      + id           = (known after apply)
      + path         = "secret/dsde/monster/dev/processing-projects/encode/s3-downloader"
    }

Plan: 6 to add, 0 to change, 3 to destroy.
```
The destroys are from moving the existing test account into a module. I'll `terraform state mv` the pieces into the right place once I get +1s to the overall changes, before I apply