### PR TITLE
Refactor how we deploy argo controllers.

### DIFF
--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -1,2 +1,6 @@
 enable: true
-schedule: '0 20 * * *'
+schedule: '15 15 * * *'
+argo:
+  env: dev
+  namespace: clinvar
+  artifactBucket: broad-dsp-monster-clingen-dev-argo-archive

--- a/environments/dev/helm/orchestration-workflows/encode/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/encode/values.yaml
@@ -1,2 +1,6 @@
 enable: true
 schedule: '0 8 * * *'
+argo:
+  env: dev
+  namespace: encode
+  artifactBucket: broad-dsp-monster-encode-dev-argo-archive

--- a/templates/helm/argo-controller/Chart.yaml
+++ b/templates/helm/argo-controller/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: argo-controller
+description: Value-template for deploying an Argo controller instance.
+version: 0.0.0

--- a/templates/helm/argo-controller/templates/argo.yaml
+++ b/templates/helm/argo-controller/templates/argo.yaml
@@ -5,9 +5,9 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: argo-server-secrets
+  name: {{ .Release.Name }}-argo-secrets
 spec:
-  releaseName: argo-server-secrets
+  releaseName: {{ .Release.Name }}-argo-secrets
   targetNamespace: secrets-manager
   resetValues: true
   chart:
@@ -17,7 +17,7 @@ spec:
   values:
     secrets:
       - secretName: {{ $secretName }}
-        nameSpace: argo-ui
+        nameSpace: {{ .Values.namespace }}
         vals:
           - kubeSecretKey: {{ $keyName }}
             path: secret/dsde/monster/{{ $env }}/command-center/cloudsql/users/argo
@@ -26,18 +26,19 @@ spec:
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: argo-server
+  name: {{ .Release.Name }}-argo-controller
 spec:
-  releaseName: argo
-  targetNamespace: argo-ui
+  releaseName: {{ .Release.Name }}-argo
+  targetNamespace: {{ .Values.namespace }}
   resetValues: true
   chart:
     repository: https://broadinstitute.github.io/monster-helm
-    name: argo-server
+    name: argo-controller
     version: 0.7.0
   values:
+    logs:
+      bucket: {{ .Values.artifactBucket }}
     clusterName: command-center-cluster
-    stackdriverProject: broad-dsp-monster-{{ .Values.env }}
     debug: {{ eq $env "dev" }}
     persistence:
       host: cloudsql-proxy-gcloud-sqlproxy.cloudsql-proxy
@@ -47,8 +48,19 @@ spec:
       password:
         secretName: {{ $secretName }}
         secretKey: {{ $keyName }}
-    service:
-      ingress:
-        create: true
-        ipName: argo-ip
-        domainName: argo.monster-{{ .Values.env }}.broadinstitute.org
+    workflowDefaults:
+      {{ $isDev := eq $env "dev" }}
+      podGarbageCollection:
+        enabled: {{ not $isDev }}
+        {{- if not $isDev }}
+        strategy: OnWorkflowSuccess
+        {{- end }}
+      workflowTTL:
+        enabled: true
+        {{- /*
+             * Timing translations:
+             *   - In dev, keep successes for 1 day, failures for a week
+             *   - In prod, keep successes for 1 hour, failures for 3 days
+             */}}
+        secondsAfterSuccess: {{ if $isDev }}86400{{ else }}3600{{ end }}
+        secondsAfterFailure: {{ if $isDev }}604800{{ else }}259200{{ end }}

--- a/templates/helm/argo-controller/values.schema.json
+++ b/templates/helm/argo-controller/values.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "env": { "type": "string", "enum": ["dev"] },
+    "namespace": { "type": "string" },
+    "artifactBucket": { "type": "string" }
+  },
+  "required": ["env", "namespace", "artifactBucket"]
+}

--- a/templates/helm/command-center/values.schema.json
+++ b/templates/helm/command-center/values.schema.json
@@ -11,11 +11,7 @@
         "region": { "type": "string" }
       },
       "required": ["name", "project", "region"]
-    },
-    "argoNamespaces": {
-      "type": "array",
-      "items": { "type": "string" }
     }
   },
-  "required": ["env", "cloudsql", "argoNamespaces"]
+  "required": ["env", "cloudsql"]
 }

--- a/templates/helm/orchestration-workflows/clinvar/Chart.yaml
+++ b/templates/helm/orchestration-workflows/clinvar/Chart.yaml
@@ -2,3 +2,8 @@ apiVersion: v2
 name: clinvar-ingest
 description: Argo workflow for regular ingest of ClinVar archives.
 version: 0.0.0
+dependencies:
+  - name: argo-controller
+    version: 0.0.0
+    repository: file:///charts/argo-controller
+    alias: argo

--- a/templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml
+++ b/templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml
@@ -38,7 +38,6 @@ spec:
     ref: master
     path: orchestration
   values:
-    maxParallelism: 1 # Weep
     gcs:
       bucketName: {{ $project }}-staging-storage
       resultBucketName: {{ $project }}-ingest-results

--- a/templates/helm/orchestration-workflows/encode/Chart.yaml
+++ b/templates/helm/orchestration-workflows/encode/Chart.yaml
@@ -2,3 +2,8 @@ apiVersion: v2
 name: encode-ingest
 description: Argo workflow for regular ingest of ENCODE data.
 version: 0.0.0
+dependencies:
+  - name: argo-controller
+    version: 0.0.0
+    repository: file:///charts/argo-controller
+    alias: argo


### PR DESCRIPTION
Our latest update to the argo-controller chart introduced a required input for "log bucket". The values of those buckets vary across projects and environments, so it's not easy to encode a uniform pattern in the generic "command center" deployment.

I've been questioning the value of having central "command center" infrastructure vs. stand-alone deployments for each project. To take a step in the stand-alone direction, I refactored the argo-controller deployment to run as part of our workflow deploy in each namespace. The log-bucket name is passed in the `values.yaml` used for the specific project/environment.