### PR TITLE
Ra dspdc 1252 workload identity issue

### DIFF
--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -228,14 +228,14 @@ data google_project current_project {
   provider = google-beta.target
 }
 
-//resource google_service_account_iam_binding hca_workload_identity_binding {
-//  provider = google-beta.target
-//
-//  service_account_id = module.hca_argo_runner_account.id
-//  role = "roles/iam.workloadIdentityUser"
-//  members = ["serviceAccount:${data.google_project.current_project.id}.svc.id.goog[hca/argo-runner]"]
-//  depends_on = [module.hca_argo_runner_account]
-//}
+resource google_service_account_iam_binding hca_workload_identity_binding {
+  provider = google-beta.target
+
+  service_account_id = module.hca_argo_runner_account.id
+  role = "roles/iam.workloadIdentityUser"
+  members = ["serviceAccount:${local.prod_project_id}.svc.id.goog[hca/argo-runner]"]
+  depends_on = [module.hca_argo_runner_account]
+}
 
 resource google_service_account_iam_binding dataflow_runner_user_binding {
   provider = google-beta.target


### PR DESCRIPTION
Fixed workload identity; we have historically been using the project name throughout our TF code, but for hca-prod, we were not able to secure a name that is the exact same as the project id, which caused some weirdness. Turns out using the project id prepends "projects/" to the id, which resulted in the service account name being invalid, which makes sense. Providing the project ID as a local variable and passing that in fixed it.