### PR TITLE
Update HCA infrastructure/deployment to be more performant

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Why
+
+[Relevant ticket](https://broadinstitute.atlassian.net/browse/<ticket_id>)
+
+## This PR

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -30,7 +30,7 @@ module node_pool {
   location = "us-central1-c"
 
   node_count = 3
-  machine_type = "n1-standard-2"
+  machine_type = "n1-standard-4"
   disk_size_gb = 30
 
   autoscaling = null

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -30,7 +30,7 @@ module node_pool {
   location = "us-central1-c"
 
   node_count = 3
-  machine_type = "n1-standard-2"
+  machine_type = "n1-standard-4"
   disk_size_gb = 30
 
   autoscaling = null

--- a/templates/helm/argo-controller/Chart.yaml
+++ b/templates/helm/argo-controller/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-controller
 description: Value-template for deploying an Argo controller instance.
-version: 0.0.0
+version: 0.0.1

--- a/templates/helm/argo-controller/templates/argo.yaml
+++ b/templates/helm/argo-controller/templates/argo.yaml
@@ -34,7 +34,7 @@ spec:
   chart:
     repository: https://broadinstitute.github.io/monster-helm
     name: argo-controller
-    version: 0.7.2
+    version: 0.7.5
   values:
     logs:
       bucket: {{ .Values.artifactBucket }}

--- a/templates/helm/orchestration-workflows/hca-mvp/Chart.yaml
+++ b/templates/helm/orchestration-workflows/hca-mvp/Chart.yaml
@@ -4,6 +4,6 @@ description: Argo workflow for regular ingest of HCA data.
 version: 0.0.0
 dependencies:
   - name: argo-controller
-    version: 0.0.0
+    version: 0.0.1
     repository: file:///charts/argo-controller
     alias: argo

--- a/templates/helm/orchestration-workflows/hca/Chart.yaml
+++ b/templates/helm/orchestration-workflows/hca/Chart.yaml
@@ -4,6 +4,6 @@ description: Argo workflow for regular ingest of HCA data.
 version: 0.0.0
 dependencies:
   - name: argo-controller
-    version: 0.0.0
+    version: 0.0.1
     repository: file:///charts/argo-controller
     alias: argo

--- a/templates/helm/orchestration-workflows/hca/templates/workflow.yaml
+++ b/templates/helm/orchestration-workflows/hca/templates/workflow.yaml
@@ -56,18 +56,20 @@ spec:
       useFlexRS: {{ eq .Values.env "prod" }}
     bigquery:
       stagingData:
-        project: {{ $projectName }}
+        project: {{ $projectId }}
         datasetPrefix: ingest_staging
         description: 'Temporary storage for HCA ingest'
         # 7 days in units of seconds
         expiration: '604800'
       jadeData:
-        project: broad-datarepo-terra-prod-hca
-        dataset: datarepo_broad_dsp_hca
+        project: broad-datarepo-terra-prod-hca2
+        # isn't used, TODO remove from hca chart
+        dataset: datarepo_hca_prod_20201106
     repo:
       url: https://jade-terra.datarepo-prod.broadinstitute.org
-      datasetId: 7c311f7f-8df0-43a6-b0c4-f9d1b37de6da
-      profileId: 1da21148-2acb-4b1c-a2a2-1fe71a74d2b3
+      # isn't used, TODO remove from hca chart
+      datasetId: 68c08a1d-78fe-41ca-92bd-eff5d78b5f57
+      profileId: db61c343-6dfe-4d14-84e9-60ddf97ea73f
       accessKey:
         secretName: {{ $secretName }}
         secretKey: {{ $keyName }}


### PR DESCRIPTION
## Why
When running a large import, the k8s cluster/argo workflow process was struggling at times. Namely, the argo-controller kept crashing. We ought to point to a new version of our argo-controller chart that makes sure the controller has more memory, and allocate slightly beefier machines for the cluster.

## This PR
- bump up machine types for hca dev and prod
- update argo controller version and corresponding chart version
- fix use of projectId vs projectName in hca orch-workflow