### PR TITLE
Run Terraform plan when TF config changes in PR

### DIFF
--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -46,9 +46,6 @@ jobs:
           SECRET_ID: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 
-      - name: aeiou
-        run: echo ${{ secrets.MONSTER_AUTH_ROLE_ID }}
-
       - name: "${{ matrix.environment }} consul-template render templates for terraform"
         uses: broadinstitute/github-action-consul-template@master
         with:

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -62,6 +62,8 @@ jobs:
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init
         run: terraform init ${{ env.terraform_directory }}
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -59,6 +59,9 @@ jobs:
         run: terraform fmt -check -recursive
         continue-on-error: true
 
+      - name: aeiou
+        run: echo ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init
         run: terraform init ${{ env.terraform_directory }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -14,7 +14,6 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # steve was here
         # environment: [dev, hca, hca-prod, prod, v2f-prod]
         environment: [dev]
     env:

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -22,14 +22,7 @@ jobs:
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest
-    container:
-      image: node:10.16-jessie
-      volumes:
-        - "${{ github.workspace }}:${{ github.workspace }}:z"
-        - "${{ github.workspace }}/environments/${{ matrix.environment }}:/env:z"
-        - "${{ github.workspace }}/templates/terraform:/templates:z"
     steps:
-
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2
 
@@ -38,26 +31,20 @@ jobs:
         with:
           terraform_version: ${{ env.terraform_version }}
 
-      - name: test ls workspace
-        run: ls -la ${{ github.workspace }}/templates/terraform
-
-      - name: test ls templates source
-        run: ls -la /templates
-
-      # - name: "${{ matrix.environment }} set VAULT_TOKEN"
-      #   id: token
-      #   run: |
-      #     VAULT_TOKEN=$(curl \
-      #       --request POST \
-      #       --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
-      #       ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
-      #     echo ::add-mask::${VAULT_TOKEN}
-      #     echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
-      #     echo ::set-output name=vault_token::${VAULT_TOKEN}
-      #   env:
-      #     ROLE_ID: ${{ secrets.ROLE_ID }}
-      #     SECRET_ID: ${{ secrets.SECRET_ID }}
-      #     VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      - name: "${{ matrix.environment }} set VAULT_TOKEN"
+        id: token
+        run: |
+          VAULT_TOKEN=$(curl \
+            --request POST \
+            --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
+            ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
+          echo ::add-mask::${VAULT_TOKEN}
+          echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
+          echo ::set-output name=vault_token::${VAULT_TOKEN}
+        env:
+          ROLE_ID: ${{ secrets.ROLE_ID }}
+          SECRET_ID: ${{ secrets.SECRET_ID }}
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 
       - name: Terraform fmt
         id: fmt

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -63,6 +63,14 @@ jobs:
           ROLE_ID: ${{ secrets[matrix.vault_role_id_secret] }}
           SECRET_ID: ${{ secrets[matrix.vault_secret_id_secret] }}
 
+      - name: "${{ matrix.environment }} consul-template render templates for terraform"
+        uses: broadinstitute/github-action-consul-template@master
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-token: ${{ steps.token.outputs.vault_token }}
+          environment: ${{ matrix.environment }}
+          env_path: "environments"
+
       - name: Terraform fmt
         id: fmt
         run: terraform fmt -check -recursive -diff=true

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -29,7 +29,7 @@ jobs:
         - "${{ github.workspace }}/templates/terraform:/templates"
     steps:
       - name: test ls base working dir precheckout
-        run: ls -la /__w/monster-deploy
+        run: ls -la /__w/monster-deploy/monster-deploy
 
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
           terraform_version: ${{ env.terraform_version }}
 
       - name: test ls base working dir
-        run: ls -la /__w/monster-deploy
+        run: ls -la /__w/monster-deploy/monster-deploy
 
       - name: test ls workspace
         run: ls ${{ github.workspace }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -53,8 +53,7 @@ jobs:
 
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init
-        run: terraform init
-        working-directory: ${{ env.terraform_directory }}
+        run: terraform init ${{ env.terraform_directory }}
 
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -1,6 +1,6 @@
 name: 'Terraform Plan'
 env:
-  terraform_version: "0.13.5"
+  terraform_version: "0.12.24"
 on:
   pull_request:
     paths:

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -36,15 +36,11 @@ jobs:
         with:
           terraform_version: ${{ env.terraform_version }}
 
-      - name: test print root dir
+      - name: test ls templates
         run: ls /templates
 
-      - name: test print root dir env
-        run: ls /env
-
-      - name: test print root dir workingdir
-        run: ls /
-        working-directory: ${{ env.terraform_directory }}
+      - name: test ls templates source
+        run: ls ${{ github.workspace }}/templates/terraform
 
       # - name: "${{ matrix.environment }} set VAULT_TOKEN"
       #   id: token

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -54,6 +54,7 @@ jobs:
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init
         run: terraform init ${{ env.terraform_directory }}
+        working-directory: ${{ env.terraform_directory }}
 
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -29,8 +29,6 @@ jobs:
         - "${{ github.workspace }}/templates/terraform:/templates"
         - "${{ github.workspace }}:${{ github.workspace }}"
     steps:
-      - name: test ls base working dir precheckout
-        run: ls -la /__w/monster-deploy/monster-deploy
 
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2
@@ -40,14 +38,11 @@ jobs:
         with:
           terraform_version: ${{ env.terraform_version }}
 
-      - name: test ls base working dir
-        run: ls -la /__w/monster-deploy/monster-deploy
-
       - name: test ls workspace
         run: ls ${{ github.workspace }}
 
       - name: test ls templates source
-        run: ls ${{ github.workspace }}/templates/terraform
+        run: ls -la /templates
 
       # - name: "${{ matrix.environment }} set VAULT_TOKEN"
       #   id: token

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -46,6 +46,14 @@ jobs:
           SECRET_ID: ${{ secrets.SECRET_ID }}
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 
+      - name: "${{ matrix.environment }} consul-template render templates for terraform"
+        uses: broadinstitute/github-action-consul-template@master
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-token: ${{ steps.token.outputs.vault_token }}
+          environment: ${{ matrix.environment }}
+          env_path: "environments"
+
       - name: Terraform fmt
         id: fmt
         run: terraform fmt -check -recursive

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -33,8 +33,8 @@ jobs:
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
         - environment: v2f-prod
           vault_env: dev
-          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
-          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -21,6 +21,8 @@ jobs:
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
       AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -25,8 +25,8 @@ jobs:
     container:
       image: node:10.16-jessie
       volumes:
-        - "$GITHUB_WORKSPACE/environments/${{ matrix.environment }}:/env"
-        - "$GITHUB_WORKSPACE/templates/terraform:/templates"
+        - "${{ env.GITHUB_WORKSPACE }}/environments/${{ matrix.environment }}:/env"
+        - "${{ env.GITHUB_WORKSPACE }}/templates/terraform:/templates"
     steps:
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -29,7 +29,7 @@ jobs:
         - "${{ github.workspace }}/templates/terraform:/templates"
     steps:
       - name: test ls base working dir precheckout
-        run: ls /__w
+        run: ls -la /__w/monster-deploy
 
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
           terraform_version: ${{ env.terraform_version }}
 
       - name: test ls base working dir
-        run: ls /__w/monster-deploy
+        run: ls -la /__w/monster-deploy
 
       - name: test ls workspace
         run: ls ${{ github.workspace }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
+        environment: [dev, hca, hca-prod, prod, v2f-prod]
         include:
         - environment: [dev, hca]
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -14,12 +14,20 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        environment: [dev, hca, hca-prod, prod, v2f-prod]
         include:
-        - environment: [dev, hca]
+        - environment: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-        - environment: [hca-prod, prod, v2f-prod]
+        - environment: hca
+          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+        - environment: hca-prod
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+        - environment: prod
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+        - environment: v2f-prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
     env:

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -28,6 +28,9 @@ jobs:
         - "${{ github.workspace }}/environments/${{ matrix.environment }}:/env"
         - "${{ github.workspace }}/templates/terraform:/templates"
     steps:
+      - name: test ls base working dir precheckout
+        run: ls /__w
+
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2
 
@@ -37,7 +40,7 @@ jobs:
           terraform_version: ${{ env.terraform_version }}
 
       - name: test ls base working dir
-        run: ls /__w
+        run: ls /__w/monster-deploy
 
       - name: test ls workspace
         run: ls ${{ github.workspace }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -18,15 +18,15 @@ jobs:
         # environment: [dev, hca, hca-prod, prod, v2f-prod]
         environment: [dev]
     env:
-      terraform_directory: "${{ env.GITHUB_WORKSPACE }}/environments/${{ matrix.environment }}/terraform"
+      terraform_directory: "$GITHUB_WORKSPACE/environments/${{ matrix.environment }}/terraform"
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest
     container:
       image: node:10.16-jessie
       volumes:
-        - ${{ env.GITHUB_WORKSPACE }}/environments/${{ matrix.environment }}:/env
-        - ${{ env.GITHUB_WORKSPACE }}/templates/terraform:/templates
+        - "$GITHUB_WORKSPACE/environments/${{ matrix.environment }}:/env"
+        - "$GITHUB_WORKSPACE/templates/terraform:/templates"
     steps:
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -18,7 +18,7 @@ jobs:
         # environment: [dev, hca, hca-prod, prod, v2f-prod]
         environment: [dev]
     env:
-      terraform_directory: "/env/terraform"
+      terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest
@@ -35,6 +35,13 @@ jobs:
         uses: hashicorp/setup-terraform@v1.2.1
         with:
           terraform_version: ${{ env.terraform_version }}
+
+      - name: test print root dir
+        run: ls /
+
+      - name: test print root dir workingdir
+        run: ls /
+        working-directory: ${{ env.terraform_directory }}
 
       # - name: "${{ matrix.environment }} set VAULT_TOKEN"
       #   id: token

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -39,6 +39,9 @@ jobs:
       - name: test ls templates
         run: ls /templates
 
+      - name: test ls workspace
+        run: ls ${{ github.workspace }}
+
       - name: test ls templates source
         run: ls ${{ github.workspace }}/templates/terraform
 

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -27,6 +27,7 @@ jobs:
       volumes:
         - "${{ github.workspace }}/environments/${{ matrix.environment }}:/env"
         - "${{ github.workspace }}/templates/terraform:/templates"
+        - "${{ github.workspace }}:${{ github.workspace }}"
     steps:
       - name: test ls base working dir precheckout
         run: ls -la /__w/monster-deploy/monster-deploy

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -20,27 +20,22 @@ jobs:
           vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-          lock: null
         - environment: hca
           vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-          lock: "1607627373520617"
         - environment: hca-prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-          lock: "1607627374555235"
         - environment: prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-          lock: null
         - environment: v2f-prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-          lock: null
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -99,13 +94,6 @@ jobs:
         continue-on-error: true
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-
-      - name: "${{ matrix.environment }} - Terraform Unlock"
-        id: unlock
-        run: terraform force-unlock -force ${{ matrix.lock }} ${{ env.terraform_directory }}
-        env:
-          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-        if: ${{ matrix.lock }}
 
       - name: "${{ matrix.environment }} - Terraform Plan"
         id: plan

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -100,6 +100,7 @@ jobs:
         continue-on-error: true
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+      # Steve.
 
       - name: Outputs
         uses: actions/github-script@0.9.0

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -25,8 +25,8 @@ jobs:
     container:
       image: node:10.16-jessie
       volumes:
-        - "${{ env.GITHUB_WORKSPACE }}/environments/${{ matrix.environment }}:/env"
-        - "${{ env.GITHUB_WORKSPACE }}/templates/terraform:/templates"
+        - "${{ GITHUB_WORKSPACE }}/environments/${{ matrix.environment }}:/env"
+        - "${{ GITHUB_WORKSPACE }}/templates/terraform:/templates"
     steps:
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Terraform fmt
         id: fmt
-        run: terraform fmt -check -recursive
+        run: terraform fmt -check -recursive -diff=true
         continue-on-error: true
 
       - name: "${{ matrix.environment }} - Terraform Init"

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           terraform_version: ${{ env.terraform_version }}
 
-      - name: test ls templates
-        run: ls /templates
+      - name: test ls base working dir
+        run: ls /__w
 
       - name: test ls workspace
         run: ls ${{ github.workspace }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -65,6 +65,11 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
+      - name: print providers for testing
+        run: terraform providers ${{ env.terraform_directory }}
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
+
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate
         run: terraform validate -no-color ${{ env.terraform_directory }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -13,6 +13,7 @@ jobs:
   terraform_plan:
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         include:
         - environment: dev
@@ -100,7 +101,6 @@ jobs:
         continue-on-error: true
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-      # Steve.
 
       - name: Outputs
         uses: actions/github-script@0.9.0

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -20,22 +20,27 @@ jobs:
           vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+          lock: null
         - environment: hca
           vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+          lock: 1607627373520617
         - environment: hca-prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+          lock: 1607627374555235
         - environment: prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+          lock: null
         - environment: v2f-prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+          lock: null
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -94,6 +99,13 @@ jobs:
         continue-on-error: true
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+
+      - name: "${{ matrix.environment }} - Terraform Unlock"
+        id: unlock
+        run: terraform force-unlock  ${{ matrix.lock }}
+        env:
+          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+        if: ${{ matrix.lock }}
 
       - name: "${{ matrix.environment }} - Terraform Plan"
         id: plan

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -54,7 +54,6 @@ jobs:
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init
         run: terraform init ${{ env.terraform_directory }}
-        working-directory: ${{ env.terraform_directory }}
 
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -14,7 +14,22 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        environment: [dev, hca, hca-prod, prod, v2f-prod]
+        include:
+        - environment: dev
+          vault_role_id: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+          vault_secret_id: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
+        - environment: hca
+          vault_role_id: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+          vault_secret_id: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
+        - environment: hca-prod
+          vault_role_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
+          vault_secret_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
+        - environment: prod
+          vault_role_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
+          vault_secret_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
+        - environment: v2f-prod
+          vault_role_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
+          vault_secret_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -34,7 +49,7 @@ jobs:
         with:
           terraform_version: ${{ env.terraform_version }}
 
-      - name: "${{ matrix.environment }} set dev VAULT_TOKEN"
+      - name: "${{ matrix.environment }} set VAULT_TOKEN"
         id: token
         run: |
           VAULT_TOKEN=$(curl \
@@ -45,32 +60,8 @@ jobs:
           echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
           echo ::set-output name=vault_token::${VAULT_TOKEN}
         env:
-          ROLE_ID: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
-          SECRET_ID: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-        if: "contains(['dev', 'hca'], matrix.environment)"
-
-      - name: "${{ matrix.environment }} set prod VAULT_TOKEN"
-        id: token
-        run: |
-          VAULT_TOKEN=$(curl \
-            --request POST \
-            --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
-            ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
-          echo ::add-mask::${VAULT_TOKEN}
-          echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
-          echo ::set-output name=vault_token::${VAULT_TOKEN}
-        env:
-          ROLE_ID: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
-          SECRET_ID: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
-        if: "contains(['hca-prod', 'prod', 'v2f-prod'], matrix.environment)"
-
-      - name: "${{ matrix.environment }} consul-template render templates for terraform"
-        uses: broadinstitute/github-action-consul-template@master
-        with:
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-token: ${{ steps.token.outputs.vault_token }}
-          environment: ${{ matrix.environment }}
-          env_path: "environments"
+          ROLE_ID: ${{ matrix.vault_role_id }}
+          SECRET_ID: ${{ matrix.vault_secret_id }}
 
       - name: Terraform fmt
         id: fmt

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -20,6 +20,7 @@ jobs:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
+      AWS_REGION: us-east-1
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -25,12 +25,12 @@ jobs:
           vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-          lock: 1607627373520617
+          lock: "1607627373520617"
         - environment: hca-prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-          lock: 1607627374555235
+          lock: "1607627374555235"
         - environment: prod
           vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
@@ -102,9 +102,10 @@ jobs:
 
       - name: "${{ matrix.environment }} - Terraform Unlock"
         id: unlock
-        run: terraform force-unlock  ${{ matrix.lock }}
+        run: terraform force-unlock ${{ matrix.lock }} --force
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+        working-directory: ${{ env.terraform_directory }}
         if: ${{ matrix.lock }}
 
       - name: "${{ matrix.environment }} - Terraform Plan"

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -102,10 +102,9 @@ jobs:
 
       - name: "${{ matrix.environment }} - Terraform Unlock"
         id: unlock
-        run: terraform force-unlock ${{ matrix.lock }} --force
+        run: terraform force-unlock ${{ matrix.lock }} ${{ env.terraform_directory }} -force
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-        working-directory: ${{ env.terraform_directory }}
         if: ${{ matrix.lock }}
 
       - name: "${{ matrix.environment }} - Terraform Plan"

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -16,18 +16,23 @@ jobs:
       matrix:
         include:
         - environment: dev
+          vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
         - environment: hca
+          vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
         - environment: hca-prod
+          vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
         - environment: prod
+          vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
         - environment: v2f-prod
+          vault_env: prod
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
     env:
@@ -68,7 +73,7 @@ jobs:
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-token: ${{ steps.token.outputs.vault_token }}
-          environment: ${{ matrix.environment }}
+          environment: ${{ matrix.vault_env }}
           env_path: "environments"
 
       - name: Terraform fmt

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -14,8 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # environment: [dev, hca, hca-prod, prod, v2f-prod]
-        environment: [dev]
+        environment: [dev, hca, hca-prod, prod, v2f-prod]
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -15,21 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-        - environment: dev
-          vault_role_id: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
-          vault_secret_id: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-        - environment: hca
-          vault_role_id: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
-          vault_secret_id: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-        - environment: hca-prod
-          vault_role_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
-          vault_secret_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
-        - environment: prod
-          vault_role_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
-          vault_secret_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
-        - environment: v2f-prod
-          vault_role_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
-          vault_secret_id: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
+        - environment: [dev, hca]
+          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+        - environment: [hca-prod, prod, v2f-prod]
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -60,8 +51,8 @@ jobs:
           echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
           echo ::set-output name=vault_token::${VAULT_TOKEN}
         env:
-          ROLE_ID: ${{ matrix.vault_role_id }}
-          SECRET_ID: ${{ matrix.vault_secret_id }}
+          ROLE_ID: ${{ secrets[matrix.vault_role_id_secret] }}
+          SECRET_ID: ${{ secrets[matrix.vault_secret_id_secret] }}
 
       - name: Terraform fmt
         id: fmt

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -25,9 +25,9 @@ jobs:
     container:
       image: node:10.16-jessie
       volumes:
-        - "${{ github.workspace }}:${{ github.workspace }}"
-        - "${{ github.workspace }}/environments/${{ matrix.environment }}:/env"
-        - "${{ github.workspace }}/templates/terraform:/templates"
+        - "${{ github.workspace }}:${{ github.workspace }}:z"
+        - "${{ github.workspace }}/environments/${{ matrix.environment }}:/env:z"
+        - "${{ github.workspace }}/templates/terraform:/templates:z"
     steps:
 
       - name: "${{ matrix.environment }} Checkout"

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -18,6 +18,8 @@ jobs:
         environment: [dev]
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest
@@ -43,7 +45,6 @@ jobs:
         env:
           ROLE_ID: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
           SECRET_ID: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 
       - name: "${{ matrix.environment }} consul-template render templates for terraform"
         uses: broadinstitute/github-action-consul-template@master
@@ -61,27 +62,19 @@ jobs:
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init
         run: terraform init ${{ env.terraform_directory }}
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
       - name: print providers for testing
         run: terraform providers ${{ env.terraform_directory }}
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate
         run: terraform validate -no-color ${{ env.terraform_directory }}
         continue-on-error: true
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
       - name: "${{ matrix.environment }} - Terraform Plan"
         id: plan
         run: terraform plan -input=false -no-color ${{ env.terraform_directory }}
         continue-on-error: true
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
       - name: Outputs
         uses: actions/github-script@0.9.0

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -37,7 +37,10 @@ jobs:
           terraform_version: ${{ env.terraform_version }}
 
       - name: test print root dir
-        run: ls /
+        run: ls /templates
+
+      - name: test print root dir env
+        run: ls /env
 
       - name: test print root dir workingdir
         run: ls /

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -46,6 +46,9 @@ jobs:
           SECRET_ID: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 
+      - name: aeiou
+        run: echo ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+
       - name: "${{ matrix.environment }} consul-template render templates for terraform"
         uses: broadinstitute/github-action-consul-template@master
         with:
@@ -58,9 +61,6 @@ jobs:
         id: fmt
         run: terraform fmt -check -recursive
         continue-on-error: true
-
-      - name: aeiou
-        run: echo ${{ secrets.MONSTER_AUTH_ROLE_ID }}
 
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           terraform_version: ${{ env.terraform_version }}
 
-      - name: "${{ matrix.environment }} set VAULT_TOKEN"
+      - name: "${{ matrix.environment }} set dev VAULT_TOKEN"
         id: token
         run: |
           VAULT_TOKEN=$(curl \
@@ -47,6 +47,22 @@ jobs:
         env:
           ROLE_ID: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
           SECRET_ID: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
+        if: "contains(['dev', 'hca'], matrix.environment)"
+
+      - name: "${{ matrix.environment }} set prod VAULT_TOKEN"
+        id: token
+        run: |
+          VAULT_TOKEN=$(curl \
+            --request POST \
+            --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
+            ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
+          echo ::add-mask::${VAULT_TOKEN}
+          echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
+          echo ::set-output name=vault_token::${VAULT_TOKEN}
+        env:
+          ROLE_ID: ${{ secrets.MONSTER_PROD_AUTH_ROLE_ID }}
+          SECRET_ID: ${{ secrets.MONSTER_PROD_AUTH_ROLE_SECRET }}
+        if: "contains(['hca-prod', 'prod', 'v2f-prod'], matrix.environment)"
 
       - name: "${{ matrix.environment }} consul-template render templates for terraform"
         uses: broadinstitute/github-action-consul-template@master

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -18,15 +18,15 @@ jobs:
         # environment: [dev, hca, hca-prod, prod, v2f-prod]
         environment: [dev]
     env:
-      terraform_directory: "$GITHUB_WORKSPACE/environments/${{ matrix.environment }}/terraform"
+      terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest
     container:
       image: node:10.16-jessie
       volumes:
-        - "${{ GITHUB_WORKSPACE }}/environments/${{ matrix.environment }}:/env"
-        - "${{ GITHUB_WORKSPACE }}/templates/terraform:/templates"
+        - "${{ github.workspace }}/environments/${{ matrix.environment }}:/env"
+        - "${{ github.workspace }}/templates/terraform:/templates"
     steps:
       - name: "${{ matrix.environment }} Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: "${{ matrix.environment }} - Terraform Unlock"
         id: unlock
-        run: terraform force-unlock ${{ matrix.lock }} ${{ env.terraform_directory }} -force
+        run: terraform force-unlock -force ${{ matrix.lock }} ${{ env.terraform_directory }}
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
         if: ${{ matrix.lock }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -42,8 +42,8 @@ jobs:
           echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
           echo ::set-output name=vault_token::${VAULT_TOKEN}
         env:
-          ROLE_ID: ${{ secrets.ROLE_ID }}
-          SECRET_ID: ${{ secrets.SECRET_ID }}
+          ROLE_ID: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+          SECRET_ID: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 
       - name: "${{ matrix.environment }} consul-template render templates for terraform"

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -67,14 +67,17 @@ jobs:
 
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate
-        run: terraform validate -no-color
+        run: terraform validate -no-color ${{ env.terraform_directory }}
         continue-on-error: true
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
       - name: "${{ matrix.environment }} - Terraform Plan"
         id: plan
-        run: terraform plan -var-file=variables.tf -input=false -no-color
-        working-directory: ${{ env.terraform_directory }}
+        run: terraform plan -input=false -no-color ${{ env.terraform_directory }}
         continue-on-error: true
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
 
       - name: Outputs
         uses: actions/github-script@0.9.0

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -33,9 +33,9 @@ jobs:
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
         - environment: v2f-prod
-          vault_env: dev
-          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
-          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+          vault_env: prod
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
     env:
       terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -32,7 +32,7 @@ jobs:
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
         - environment: v2f-prod
-          vault_env: prod
+          vault_env: dev
           vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
           vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
     env:
@@ -84,19 +84,22 @@ jobs:
       - name: "${{ matrix.environment }} - Terraform Init"
         id: init
         run: terraform init ${{ env.terraform_directory }}
-
-      - name: print providers for testing
-        run: terraform providers ${{ env.terraform_directory }}
+        env:
+          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
 
       - name: "${{ matrix.environment }} - Terraform Validate"
         id: validate
         run: terraform validate -no-color ${{ env.terraform_directory }}
         continue-on-error: true
+        env:
+          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
 
       - name: "${{ matrix.environment }} - Terraform Plan"
         id: plan
         run: terraform plan -input=false -no-color ${{ env.terraform_directory }}
         continue-on-error: true
+        env:
+          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
 
       - name: Outputs
         uses: actions/github-script@0.9.0

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -25,9 +25,9 @@ jobs:
     container:
       image: node:10.16-jessie
       volumes:
+        - "${{ github.workspace }}:${{ github.workspace }}"
         - "${{ github.workspace }}/environments/${{ matrix.environment }}:/env"
         - "${{ github.workspace }}/templates/terraform:/templates"
-        - "${{ github.workspace }}:${{ github.workspace }}"
     steps:
 
       - name: "${{ matrix.environment }} Checkout"
@@ -39,7 +39,7 @@ jobs:
           terraform_version: ${{ env.terraform_version }}
 
       - name: test ls workspace
-        run: ls ${{ github.workspace }}
+        run: ls -la ${{ github.workspace }}/templates/terraform
 
       - name: test ls templates source
         run: ls -la /templates

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -18,7 +18,7 @@ jobs:
         # environment: [dev, hca, hca-prod, prod, v2f-prod]
         environment: [dev]
     env:
-      terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
+      terraform_directory: "/env/terraform"
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     name: "${{ matrix.environment }} Terraform Plan"
     runs-on: ubuntu-latest

--- a/environments/dev/terraform/aws.tf
+++ b/environments/dev/terraform/aws.tf
@@ -18,12 +18,10 @@ provider aws {
 resource aws_s3_bucket s3_east_bucket {
   provider = aws.us-east-1
   bucket   = "monster-s3-us-east-1"
-  region   = "us-east-1"
 }
 resource aws_s3_bucket s3_west_bucket {
   provider = aws.us-west-2
   bucket   = "monster-s3-us-west-2"
-  region   = "us-west-2"
 }
 
 ###

--- a/environments/dev/terraform/aws.tf
+++ b/environments/dev/terraform/aws.tf
@@ -4,11 +4,11 @@
 ###
 provider aws {
   region = "us-east-1"
-  alias = "us-east-1"
+  alias  = "us-east-1"
 }
 provider aws {
   region = "us-west-2"
-  alias = "us-west-2"
+  alias  = "us-west-2"
 }
 
 ###
@@ -17,13 +17,13 @@ provider aws {
 ###
 resource aws_s3_bucket s3_east_bucket {
   provider = aws.us-east-1
-  bucket = "monster-s3-us-east-1"
-  region = "us-east-1"
+  bucket   = "monster-s3-us-east-1"
+  region   = "us-east-1"
 }
 resource aws_s3_bucket s3_west_bucket {
   provider = aws.us-west-2
-  bucket = "monster-s3-us-west-2"
-  region = "us-west-2"
+  bucket   = "monster-s3-us-west-2"
+  region   = "us-west-2"
 }
 
 ###
@@ -34,14 +34,14 @@ module test_transfer_user {
     aws.target = aws.us-east-1
   }
 
-  source = "../../../templates/terraform/aws-sa"
+  source     = "../../../templates/terraform/aws-sa"
   account_id = "monster-s3-tester"
   vault_path = "${local.vault_prefix}/aws/s3-transfer-user"
 
   iam_policy = [
     {
       subject_id = "ListObjects",
-      actions = ["s3:ListBucket"],
+      actions    = ["s3:ListBucket"],
       resources = [
         aws_s3_bucket.s3_east_bucket.arn,
         aws_s3_bucket.s3_west_bucket.arn
@@ -49,7 +49,7 @@ module test_transfer_user {
     },
     {
       subject_id = "ObjectActions",
-      actions = ["s3:*Object"]
+      actions    = ["s3:*Object"]
       resources = [
         "${aws_s3_bucket.s3_east_bucket.arn}/*",
         "${aws_s3_bucket.s3_west_bucket.arn}/*"

--- a/environments/dev/terraform/aws.tf
+++ b/environments/dev/terraform/aws.tf
@@ -34,7 +34,7 @@ module test_transfer_user {
     aws.target = aws.us-east-1
   }
 
-  source = "/templates/aws-sa"
+  source = "../../templates/aws-sa"
   account_id = "monster-s3-tester"
   vault_path = "${local.vault_prefix}/aws/s3-transfer-user"
 

--- a/environments/dev/terraform/aws.tf
+++ b/environments/dev/terraform/aws.tf
@@ -34,7 +34,7 @@ module test_transfer_user {
     aws.target = aws.us-east-1
   }
 
-  source = "../../templates/aws-sa"
+  source = "./templates/aws-sa"
   account_id = "monster-s3-tester"
   vault_path = "${local.vault_prefix}/aws/s3-transfer-user"
 

--- a/environments/dev/terraform/aws.tf
+++ b/environments/dev/terraform/aws.tf
@@ -34,7 +34,7 @@ module test_transfer_user {
     aws.target = aws.us-east-1
   }
 
-  source = "../../../templates/aws-sa"
+  source = "../../../../templates/aws-sa"
   account_id = "monster-s3-tester"
   vault_path = "${local.vault_prefix}/aws/s3-transfer-user"
 

--- a/environments/dev/terraform/aws.tf
+++ b/environments/dev/terraform/aws.tf
@@ -34,7 +34,7 @@ module test_transfer_user {
     aws.target = aws.us-east-1
   }
 
-  source = "./templates/aws-sa"
+  source = "../../../templates/aws-sa"
   account_id = "monster-s3-tester"
   vault_path = "${local.vault_prefix}/aws/s3-transfer-user"
 

--- a/environments/dev/terraform/aws.tf
+++ b/environments/dev/terraform/aws.tf
@@ -34,7 +34,7 @@ module test_transfer_user {
     aws.target = aws.us-east-1
   }
 
-  source = "../../../../templates/aws-sa"
+  source = "../../../templates/terraform/aws-sa"
   account_id = "monster-s3-tester"
   vault_path = "${local.vault_prefix}/aws/s3-transfer-user"
 

--- a/environments/dev/terraform/backend.tf
+++ b/environments/dev/terraform/backend.tf
@@ -7,6 +7,7 @@
 ###
 terraform {
   backend "gcs" {
+    credentials = file("../../gcs_sa_key.json")
     bucket = "broad-dsp-monster-dev-terraform-state"
     path = "tfstate.json"
   }

--- a/environments/dev/terraform/backend.tf
+++ b/environments/dev/terraform/backend.tf
@@ -8,6 +8,6 @@
 terraform {
   backend "gcs" {
     bucket = "broad-dsp-monster-dev-terraform-state"
-    path = "tfstate.json"
+    path   = "tfstate.json"
   }
 }

--- a/environments/dev/terraform/backend.tf
+++ b/environments/dev/terraform/backend.tf
@@ -7,7 +7,6 @@
 ###
 terraform {
   backend "gcs" {
-    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-dev-terraform-state"
     path = "tfstate.json"
   }

--- a/environments/dev/terraform/backend.tf
+++ b/environments/dev/terraform/backend.tf
@@ -7,7 +7,7 @@
 ###
 terraform {
   backend "gcs" {
-    credentials = file("../../gcs_sa_key.json")
+    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-dev-terraform-state"
     path = "tfstate.json"
   }

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -1,6 +1,6 @@
 # a gcs bucket
 resource google_storage_bucket monster_test_bucket {
-  provider = google-beta.command-center
+  provider = google.command-center
   name     = "monster-test-bucket"
   location = "US"
 }
@@ -8,7 +8,7 @@ resource google_storage_bucket monster_test_bucket {
 module test_sa {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.command-center,
+    google.target = google.command-center,
     vault.target  = vault.command-center
   }
 
@@ -18,7 +18,7 @@ module test_sa {
 }
 
 resource google_storage_bucket_iam_member test_iam {
-  provider = google-beta.command-center
+  provider = google.command-center
   bucket   = google_storage_bucket.monster_test_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -1,7 +1,7 @@
 # a gcs bucket
 resource google_storage_bucket monster_test_bucket {
   provider = google-beta.command-center
-  name = "monster-test-bucket"
+  name     = "monster-test-bucket"
   location = "US"
 }
 
@@ -9,21 +9,21 @@ module test_sa {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.command-center,
-    vault.target = vault.command-center
+    vault.target  = vault.command-center
   }
 
-  account_id = "monster-dev-test-sa"
+  account_id   = "monster-dev-test-sa"
   display_name = "test-sa"
-  vault_path = "${local.vault_prefix}/gcs/gcs-transfer-user-key"
+  vault_path   = "${local.vault_prefix}/gcs/gcs-transfer-user-key"
 }
 
 resource google_storage_bucket_iam_member test_iam {
   provider = google-beta.command-center
-  bucket = google_storage_bucket.monster_test_bucket.name
+  bucket   = google_storage_bucket.monster_test_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.test_sa.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.test_sa.email}"
   depends_on = [module.test_sa.delay]
 }

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -6,7 +6,7 @@ resource google_storage_bucket monster_test_bucket {
 }
 
 module test_sa {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.command-center

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -6,7 +6,7 @@ resource google_storage_bucket monster_test_bucket {
 }
 
 module test_sa {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.command-center

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -6,7 +6,7 @@ resource google_storage_bucket monster_test_bucket {
 }
 
 module test_sa {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.command-center

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -6,7 +6,7 @@ resource google_storage_bucket monster_test_bucket {
 }
 
 module test_sa {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.command-center

--- a/environments/dev/terraform/gcs.tf
+++ b/environments/dev/terraform/gcs.tf
@@ -6,7 +6,7 @@ resource google_storage_bucket monster_test_bucket {
 }
 
 module test_sa {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.command-center

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "../../../../templates/monster-infrastructure"
+  source = "../../../templates/terraform/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -1,5 +1,4 @@
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-dev"
   region = "us-central1"
   alias = "command-center"
@@ -10,14 +9,12 @@ provider vault {
 }
 
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-clingen-dev"
   region = "us-central1"
   alias = "clinvar"
 }
 
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-encode-dev"
   region = "us-west1"
   alias = "encode"

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "../../../templates/monster-infrastructure"
+  source = "../../../../templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -1,4 +1,4 @@
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-dev"
   region  = "us-central1"
   alias   = "command-center"
@@ -8,13 +8,13 @@ provider vault {
   alias = "command-center"
 }
 
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-clingen-dev"
   region  = "us-central1"
   alias   = "clinvar"
 }
 
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-encode-dev"
   region  = "us-west1"
   alias   = "encode"
@@ -28,10 +28,10 @@ provider aws {
 module monster_infrastructure {
   source = "../../../templates/terraform/monster-infrastructure"
   providers = {
-    google.command-center = google-beta.command-center
+    google.command-center = google.command-center
     vault.target          = vault.command-center
-    google.clinvar        = google-beta.clinvar
-    google.encode         = google-beta.encode,
+    google.clinvar        = google.clinvar
+    google.encode         = google.encode,
     aws.encode            = aws.encode
   }
 

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -1,4 +1,4 @@
-provider google {
+provider google-beta {
   project = "broad-dsp-monster-dev"
   region  = "us-central1"
   alias   = "command-center"
@@ -8,13 +8,13 @@ provider vault {
   alias = "command-center"
 }
 
-provider google {
+provider google-beta {
   project = "broad-dsp-monster-clingen-dev"
   region  = "us-central1"
   alias   = "clinvar"
 }
 
-provider google {
+provider google-beta {
   project = "broad-dsp-monster-encode-dev"
   region  = "us-west1"
   alias   = "encode"
@@ -28,10 +28,10 @@ provider aws {
 module monster_infrastructure {
   source = "../../../templates/terraform/monster-infrastructure"
   providers = {
-    google.command-center = google.command-center
+    google.command-center = google-beta.command-center
     vault.target          = vault.command-center
-    google.clinvar        = google.clinvar
-    google.encode         = google.encode,
+    google.clinvar        = google-beta.clinvar
+    google.encode         = google-beta.encode,
     aws.encode            = aws.encode
   }
 

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "./templates/monster-infrastructure"
+  source = "../../../templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -8,13 +8,13 @@ provider vault {
   alias = "command-center"
 }
 
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-clingen-dev"
   region  = "us-central1"
   alias   = "clinvar"
 }
 
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-encode-dev"
   region  = "us-west1"
   alias   = "encode"
@@ -28,10 +28,10 @@ provider aws {
 module monster_infrastructure {
   source = "../../../templates/terraform/monster-infrastructure"
   providers = {
-    google.command-center = google-beta.command-center
+    google.command-center = google.command-center
     vault.target          = vault.command-center
-    google.clinvar        = google-beta.clinvar
-    google.encode         = google-beta.encode,
+    google.clinvar        = google.clinvar
+    google.encode         = google.encode,
     aws.encode            = aws.encode
   }
 

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "../../templates/monster-infrastructure"
+  source = "./templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "/templates/monster-infrastructure"
+  source = "../../templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -1,4 +1,5 @@
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-dev"
   region = "us-central1"
   alias = "command-center"
@@ -9,12 +10,14 @@ provider vault {
 }
 
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-clingen-dev"
   region = "us-central1"
   alias = "clinvar"
 }
 
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-encode-dev"
   region = "us-west1"
   alias = "encode"

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -1,4 +1,4 @@
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-dev"
   region  = "us-central1"
   alias   = "command-center"

--- a/environments/dev/terraform/main.tf
+++ b/environments/dev/terraform/main.tf
@@ -1,7 +1,7 @@
 provider google-beta {
   project = "broad-dsp-monster-dev"
-  region = "us-central1"
-  alias = "command-center"
+  region  = "us-central1"
+  alias   = "command-center"
 }
 
 provider vault {
@@ -10,34 +10,34 @@ provider vault {
 
 provider google-beta {
   project = "broad-dsp-monster-clingen-dev"
-  region = "us-central1"
-  alias = "clinvar"
+  region  = "us-central1"
+  alias   = "clinvar"
 }
 
 provider google-beta {
   project = "broad-dsp-monster-encode-dev"
-  region = "us-west1"
-  alias = "encode"
+  region  = "us-west1"
+  alias   = "encode"
 }
 
 provider aws {
   region = "us-east-1"
-  alias = "encode"
+  alias  = "encode"
 }
 
 module monster_infrastructure {
   source = "../../../templates/terraform/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
-    vault.target = vault.command-center
-    google.clinvar = google-beta.clinvar
-    google.encode = google-beta.encode,
-    aws.encode = aws.encode
+    vault.target          = vault.command-center
+    google.clinvar        = google-beta.clinvar
+    google.encode         = google-beta.encode,
+    aws.encode            = aws.encode
   }
 
   is_production = false
-  cluster_size = 3
-  machine_type = "n1-standard-4"
+  cluster_size  = 3
+  machine_type  = "n1-standard-4"
   # 4 CPU, 15 GiB of RAM.
   db_tier = "db-custom-4-15360"
 }

--- a/environments/gcs_sa_key.json.ctmpl
+++ b/environments/gcs_sa_key.json.ctmpl
@@ -1,0 +1,8 @@
+{{with $project := "monster" }}
+{{with $environment := env "ENVIRONMENT"}}
+{{$keyname := (printf "secret/devops/terraform/%s/%s/terraform-service-account.json" $environment $project)}}
+{{with secret $keyname}}
+{{.Data | toJSONPretty}}
+{{end}}
+{{end}}
+{{end}}

--- a/environments/hca-prod/terraform/backend.tf
+++ b/environments/hca-prod/terraform/backend.tf
@@ -1,5 +1,6 @@
 terraform {
   backend "gcs" {
+    credentials = file("../../gcs_sa_key.json")
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "hca.tfstate.json"
   }

--- a/environments/hca-prod/terraform/backend.tf
+++ b/environments/hca-prod/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    credentials = file("../../gcs_sa_key.json")
+    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "hca.tfstate.json"
   }

--- a/environments/hca-prod/terraform/backend.tf
+++ b/environments/hca-prod/terraform/backend.tf
@@ -1,6 +1,5 @@
 terraform {
   backend "gcs" {
-    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "hca.tfstate.json"
   }

--- a/environments/hca-prod/terraform/backend.tf
+++ b/environments/hca-prod/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
     bucket = "broad-dsp-monster-prod-terraform-state"
-    path = "hca.tfstate.json"
+    path   = "hca.tfstate.json"
   }
 }

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -31,7 +31,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -199,7 +199,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -212,7 +212,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -31,7 +31,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -199,7 +199,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -212,7 +212,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -31,7 +31,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -199,7 +199,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -212,7 +212,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -31,7 +31,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -199,7 +199,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -212,7 +212,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -1,31 +1,31 @@
 # bucket for EBI
 resource google_storage_bucket ebi_bucket {
   provider = google-beta.target
-  name = "${local.prod_project_name}-ebi-storage"
+  name     = "${local.prod_project_name}-ebi-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member ebi_bucket_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.ebi_bucket.name
+  bucket   = google_storage_bucket.ebi_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
   for_each = toset(["enrique@ebi.ac.uk", "rolando@ebi.ac.uk"])
 
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "user:${each.value}"
 }
 
 resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.ebi_bucket.name
+  bucket   = google_storage_bucket.ebi_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
   for_each = toset(["ebi-staging-writer@broad-dsp-monster-hca-dev.iam.gserviceaccount.com"])
 
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${each.value}"
 }
 
@@ -34,21 +34,21 @@ module ebi_writer_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "ebi-staging-writer"
+  account_id   = "ebi-staging-writer"
   display_name = "Account used by EBI to interact with their staging bucket"
-  vault_path = "${local.prod_vault_prefix}/service-accounts/ebi-storage-writer"
-  roles = ["storagetransfer.user", "storagetransfer.viewer"]
+  vault_path   = "${local.prod_vault_prefix}/service-accounts/ebi-storage-writer"
+  roles        = ["storagetransfer.user", "storagetransfer.viewer"]
 }
 
 # EBI is an admin on their bucket.
 resource google_storage_bucket_iam_member ebi_writer_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.ebi_bucket.name
-  role = "roles/storage.objectAdmin"
-  member = "serviceAccount:${module.ebi_writer_account.email}"
+  bucket   = google_storage_bucket.ebi_bucket.name
+  role     = "roles/storage.objectAdmin"
+  member   = "serviceAccount:${module.ebi_writer_account.email}"
 }
 
 # Both TDRs and our Dataflow SA can read from the bucket.
@@ -57,7 +57,7 @@ resource google_storage_bucket_iam_member tdr_ebi_reader_iam {
   for_each = toset([local.dev_repo_email, local.prod_repo_email, module.hca_dataflow_account.email])
 
   bucket = google_storage_bucket.ebi_bucket.name
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${each.value}"
 }
 
@@ -71,7 +71,7 @@ resource google_storage_bucket_iam_member sts_iam {
   for_each = toset(["storage.legacyBucketReader", "storage.objectViewer", "storage.legacyBucketWriter"])
 
   bucket = google_storage_bucket.ebi_bucket.name
-  role = "roles/${each.value}"
+  role   = "roles/${each.value}"
   member = "serviceAccount:${data.google_storage_transfer_project_service_account.sts_account.email}"
 }
 
@@ -79,19 +79,19 @@ resource google_storage_bucket_iam_member sts_iam {
 # bucket for UCSC
 resource google_storage_bucket ucsc_bucket {
   provider = google-beta.target
-  name = "${local.prod_project_name}-ucsc-storage"
+  name     = "${local.prod_project_name}-ucsc-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member ucsc_bucket_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.ucsc_bucket.name
+  bucket   = google_storage_bucket.ucsc_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
   for_each = toset(["hannes@ucsc.edu", "dsotirho@ucsc.edu"])
 
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "user:${each.value}"
 }
 
@@ -101,14 +101,14 @@ resource google_storage_bucket_iam_member tdr_ucsc_reader_iam {
   for_each = toset([local.dev_repo_email, local.prod_repo_email, module.hca_dataflow_account.email])
 
   bucket = google_storage_bucket.ucsc_bucket.name
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${each.value}"
 }
 
 # temp bucket for dataflow temporary files
 resource google_storage_bucket temp_bucket {
   provider = google-beta.target
-  name = "${local.prod_project_name}-temp-storage"
+  name     = "${local.prod_project_name}-temp-storage"
   location = "US"
 
   lifecycle_rule {
@@ -125,75 +125,75 @@ resource google_storage_bucket temp_bucket {
 
 resource google_storage_bucket_iam_member temp_bucket_runner_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.temp_bucket.name
+  bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.hca_dataflow_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.hca_dataflow_account.email}"
   depends_on = [module.hca_dataflow_account.delay]
 }
 
 resource google_storage_bucket_iam_member hca_argo_temp_bucket_iam {
   provider = google-beta.target
-  bucket =  google_storage_bucket.temp_bucket.name
+  bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_argo_runner_account.email}"
 }
 
 # staging bucket
 resource google_storage_bucket staging_storage {
   provider = google-beta.target
-  name = "${local.prod_project_name}-staging-storage"
+  name     = "${local.prod_project_name}-staging-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member staging_bucket_runner_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.hca_dataflow_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.hca_dataflow_account.email}"
   depends_on = [module.hca_dataflow_account.delay]
 }
 
 resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
   provider = google-beta.target
-  bucket =  google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_argo_runner_account.email}"
 }
 
 resource google_storage_bucket_iam_member staging_account_iam_reader {
   provider = google-beta.target
-  bucket = google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${local.prod_repo_email}"
 }
 
 # Bucket for long term Argo logs storage, currently want no "delete after N days" rule.
 resource google_storage_bucket hca_argo_archive {
   provider = google-beta.target
-  name = "${local.prod_project_name}-argo-archive"
+  name     = "${local.prod_project_name}-argo-archive"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
   provider = google-beta.target
-  bucket =  google_storage_bucket.hca_argo_archive.name
+  bucket   = google_storage_bucket.hca_argo_archive.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_argo_runner_account.email}"
 }
 # Service accounts that use these buckets
@@ -202,26 +202,26 @@ module hca_dataflow_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "hca-dataflow-runner"
+  account_id   = "hca-dataflow-runner"
   display_name = "Service account to run HCA dataflow jobs"
-  vault_path = "${local.prod_vault_prefix}/service-accounts/hca-dataflow-runner"
-  roles = ["dataflow.worker"]
+  vault_path   = "${local.prod_vault_prefix}/service-accounts/hca-dataflow-runner"
+  roles        = ["dataflow.worker"]
 }
 
 module hca_argo_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "hca-argo-runner"
+  account_id   = "hca-argo-runner"
   display_name = "Service account to run HCA's Argo workflow."
-  vault_path = "${local.prod_vault_prefix}/service-accounts/hca-argo-runner"
-  roles = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
+  vault_path   = "${local.prod_vault_prefix}/service-accounts/hca-argo-runner"
+  roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
 }
 
 data google_project current_project {
@@ -232,15 +232,15 @@ resource google_service_account_iam_binding hca_workload_identity_binding {
   provider = google-beta.target
 
   service_account_id = module.hca_argo_runner_account.id
-  role = "roles/iam.workloadIdentityUser"
-  members = ["serviceAccount:${local.prod_project_id}.svc.id.goog[hca/argo-runner]"]
-  depends_on = [module.hca_argo_runner_account]
+  role               = "roles/iam.workloadIdentityUser"
+  members            = ["serviceAccount:${local.prod_project_id}.svc.id.goog[hca/argo-runner]"]
+  depends_on         = [module.hca_argo_runner_account]
 }
 
 resource google_service_account_iam_binding dataflow_runner_user_binding {
   provider = google-beta.target
 
   service_account_id = module.hca_dataflow_account.id
-  role = "roles/iam.serviceAccountUser"
-  members = ["serviceAccount:${module.hca_argo_runner_account.email}"]
+  role               = "roles/iam.serviceAccountUser"
+  members            = ["serviceAccount:${module.hca_argo_runner_account.email}"]
 }

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -31,7 +31,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -199,7 +199,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -212,7 +212,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/cloudsql.tf
+++ b/environments/hca-prod/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "../../../../templates/cloudsql"
+  source = "../../../templates/terraform/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca-prod/terraform/cloudsql.tf
+++ b/environments/hca-prod/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "./templates/cloudsql"
+  source = "../../../templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca-prod/terraform/cloudsql.tf
+++ b/environments/hca-prod/terraform/cloudsql.tf
@@ -2,19 +2,19 @@ module cloudsql {
   source = "../../../templates/terraform/cloudsql"
   providers = {
     google.target = google-beta.target
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
   name_prefix = "command-center"
-  cpu = 4
-  ram = 15360
+  cpu         = 4
+  ram         = 15360
   labels = {
-    app = "hca"
-    role = "database"
+    app   = "hca"
+    role  = "database"
     state = "active"
   }
-  db_names = ["argo"]
-  user_names = ["argo"]
+  db_names     = ["argo"]
+  user_names   = ["argo"]
   vault_prefix = local.prod_vault_prefix
   dependencies = module.enable_services
 }

--- a/environments/hca-prod/terraform/cloudsql.tf
+++ b/environments/hca-prod/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "../../templates/cloudsql"
+  source = "./templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca-prod/terraform/cloudsql.tf
+++ b/environments/hca-prod/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "/templates/cloudsql"
+  source = "../../templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca-prod/terraform/cloudsql.tf
+++ b/environments/hca-prod/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "../../../templates/cloudsql"
+  source = "../../../../templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -1,16 +1,16 @@
 data google_dns_managed_zone prod_zone {
   provider = google-beta.prod-core
-  name = "monster-prod"
+  name     = "monster-prod"
 }
 
 module dns_names {
   source = "../../../templates/terraform/dns"
   providers = {
-    google.ip = google-beta.target,
+    google.ip  = google-beta.target,
     google.dns = google-beta.prod-core
   }
-  dependencies = [module.enable_services]
+  dependencies  = [module.enable_services]
   zone_gcp_name = data.google_dns_managed_zone.prod_zone.name
   zone_dns_name = data.google_dns_managed_zone.prod_zone.dns_name
-  dns_names = ["hca-argo", "hca-grafana"]
+  dns_names     = ["hca-argo", "hca-grafana"]
 }

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone prod_zone {
 }
 
 module dns_names {
-  source = "/templates/dns"
+  source = "../../templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.prod-core

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone prod_zone {
 }
 
 module dns_names {
-  source = "../../../templates/dns"
+  source = "../../../../templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.prod-core

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone prod_zone {
 }
 
 module dns_names {
-  source = "../../templates/dns"
+  source = "./templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.prod-core

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone prod_zone {
 }
 
 module dns_names {
-  source = "./templates/dns"
+  source = "../../../templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.prod-core

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone prod_zone {
 }
 
 module dns_names {
-  source = "../../../../templates/dns"
+  source = "../../../templates/terraform/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.prod-core

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "../../../templates/k8s-master"
+  source = "../../../../templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "../../../templates/k8s-node-pool"
+  source = "../../../../templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "../../../../templates/k8s-master"
+  source = "../../../templates/terraform/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "../../../../templates/k8s-node-pool"
+  source = "../../../templates/terraform/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "./templates/k8s-master"
+  source = "../../../templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "./templates/k8s-node-pool"
+  source = "../../../templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "../../templates/k8s-master"
+  source = "./templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "../../templates/k8s-node-pool"
+  source = "./templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "/templates/k8s-master"
+  source = "../../templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "/templates/k8s-node-pool"
+  source = "../../templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -7,10 +7,10 @@ module master {
   }
   dependencies = [module.enable_services, module.k8s_network]
 
-  name = "hca-cluster"
+  name     = "hca-cluster"
   location = "us-central1-c"
 
-  network = module.k8s_network.network_link
+  network    = module.k8s_network.network_link
   subnetwork = module.k8s_network.subnet_links[0]
 
   restrict_master_access = false
@@ -25,16 +25,16 @@ module node_pool {
   }
   dependencies = [module.enable_services, module.master]
 
-  name = "hca-node-pool"
+  name        = "hca-node-pool"
   master_name = module.master.name
-  location = "us-central1-c"
+  location    = "us-central1-c"
 
-  node_count = 3
+  node_count   = 3
   machine_type = "n1-standard-2"
   disk_size_gb = 30
 
-  autoscaling = null
-  taints = null
+  autoscaling           = null
+  taints                = null
   service_account_email = module.hca_gke_runner_account.email
 }
 
@@ -43,11 +43,11 @@ module hca_gke_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "hca-gke-runner"
+  account_id   = "hca-gke-runner"
   display_name = "Service account to run GKE system pods"
-  vault_path = "${local.prod_vault_prefix}/service-accounts/gke-runner"
-  roles = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
+  vault_path   = "${local.prod_vault_prefix}/service-accounts/gke-runner"
+  roles        = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
 }

--- a/environments/hca-prod/terraform/networks.tf
+++ b/environments/hca-prod/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "../../templates/compute-network"
+  source = "./templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/networks.tf
+++ b/environments/hca-prod/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "/templates/compute-network"
+  source = "../../templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/networks.tf
+++ b/environments/hca-prod/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "../../../../templates/compute-network"
+  source = "../../../templates/terraform/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/networks.tf
+++ b/environments/hca-prod/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "./templates/compute-network"
+  source = "../../../templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/networks.tf
+++ b/environments/hca-prod/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "../../../templates/compute-network"
+  source = "../../../../templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/networks.tf
+++ b/environments/hca-prod/terraform/networks.tf
@@ -8,7 +8,7 @@ module k8s_network {
   name = "hca-network"
   subnets = [{
     region = "us-central1",
-    cidr = "10.0.0.0/22"
+    cidr   = "10.0.0.0/22"
   }]
   enable_flow_logs = true
 }

--- a/environments/hca-prod/terraform/provider.tf
+++ b/environments/hca-prod/terraform/provider.tf
@@ -1,12 +1,10 @@
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   alias = "target"
 
   project = local.prod_project_id
   region = "us-central1"
 }
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   alias = "prod-core"
   project = "broad-dsp-monster-prod"
   region = "us-central1"

--- a/environments/hca-prod/terraform/provider.tf
+++ b/environments/hca-prod/terraform/provider.tf
@@ -1,10 +1,12 @@
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   alias = "target"
 
   project = local.prod_project_id
   region = "us-central1"
 }
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   alias = "prod-core"
   project = "broad-dsp-monster-prod"
   region = "us-central1"

--- a/environments/hca-prod/terraform/provider.tf
+++ b/environments/hca-prod/terraform/provider.tf
@@ -2,12 +2,12 @@ provider google-beta {
   alias = "target"
 
   project = local.prod_project_id
-  region = "us-central1"
+  region  = "us-central1"
 }
 provider google-beta {
-  alias = "prod-core"
+  alias   = "prod-core"
   project = "broad-dsp-monster-prod"
-  region = "us-central1"
+  region  = "us-central1"
 }
 
 provider vault {

--- a/environments/hca-prod/terraform/services.tf
+++ b/environments/hca-prod/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "../../../templates/api-services"
+  source = "../../../../templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/services.tf
+++ b/environments/hca-prod/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "../../templates/api-services"
+  source = "./templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/services.tf
+++ b/environments/hca-prod/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "./templates/api-services"
+  source = "../../../templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/services.tf
+++ b/environments/hca-prod/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "../../../../templates/api-services"
+  source = "../../../templates/terraform/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/services.tf
+++ b/environments/hca-prod/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "/templates/api-services"
+  source = "../../templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca-prod/terraform/variables.tf
+++ b/environments/hca-prod/terraform/variables.tf
@@ -1,7 +1,7 @@
 locals {
-  prod_project_id = "mystical-slate-284720"
+  prod_project_id   = "mystical-slate-284720"
   prod_project_name = "broad-dsp-monster-hca-prod"
   prod_vault_prefix = "secret/dsde/monster/prod/ingest/hca"
-  dev_repo_email = "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"
-  prod_repo_email = "terra-data-repository@broad-datarepo-terra-prod.iam.gserviceaccount.com"
+  dev_repo_email    = "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"
+  prod_repo_email   = "terra-data-repository@broad-datarepo-terra-prod.iam.gserviceaccount.com"
 }

--- a/environments/hca/terraform/backend.tf
+++ b/environments/hca/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
     bucket = "broad-dsp-monster-dev-terraform-state"
-    path = "hca.tfstate.json"
+    path   = "hca.tfstate.json"
   }
 }

--- a/environments/hca/terraform/backend.tf
+++ b/environments/hca/terraform/backend.tf
@@ -1,5 +1,6 @@
 terraform {
   backend "gcs" {
+    credentials = file("../../gcs_sa_key.json")
     bucket = "broad-dsp-monster-dev-terraform-state"
     path = "hca.tfstate.json"
   }

--- a/environments/hca/terraform/backend.tf
+++ b/environments/hca/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    credentials = file("../../gcs_sa_key.json")
+    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-dev-terraform-state"
     path = "hca.tfstate.json"
   }

--- a/environments/hca/terraform/backend.tf
+++ b/environments/hca/terraform/backend.tf
@@ -1,6 +1,5 @@
 terraform {
   backend "gcs" {
-    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-dev-terraform-state"
     path = "hca.tfstate.json"
   }

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -103,7 +103,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -116,7 +116,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -103,7 +103,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -116,7 +116,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -103,7 +103,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -116,7 +116,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -103,7 +103,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -116,7 +116,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -1,7 +1,7 @@
 # temp bucket for dataflow temporary files
 resource google_storage_bucket temp_bucket {
   provider = google-beta.target
-  name = "${local.dev_project_name}-temp-storage"
+  name     = "${local.dev_project_name}-temp-storage"
   location = "US"
 
   lifecycle_rule {
@@ -18,86 +18,86 @@ resource google_storage_bucket temp_bucket {
 
 resource google_storage_bucket_iam_member temp_bucket_runner_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.temp_bucket.name
+  bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.hca_dataflow_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.hca_dataflow_account.email}"
   depends_on = [module.hca_dataflow_account.delay]
 }
 
 resource google_storage_bucket_iam_member temp_bucket_test_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.temp_bucket.name
+  bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.hca_test_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.hca_test_account.email}"
   depends_on = [module.hca_test_account.delay]
 }
 
 resource google_storage_bucket_iam_member hca_argo_temp_bucket_iam {
   provider = google-beta.target
-  bucket =  google_storage_bucket.temp_bucket.name
+  bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_argo_runner_account.email}"
 }
 
 # staging bucket
 resource google_storage_bucket staging_storage {
   provider = google-beta.target
-  name = "${local.dev_project_name}-staging-storage"
+  name     = "${local.dev_project_name}-staging-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member staging_bucket_runner_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.hca_dataflow_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.hca_dataflow_account.email}"
   depends_on = [module.hca_dataflow_account.delay]
 }
 
 resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
   provider = google-beta.target
-  bucket =  google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_argo_runner_account.email}"
 }
 
 resource google_storage_bucket_iam_member staging_account_iam_reader {
   provider = google-beta.target
-  bucket = google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${local.dev_repo_email}"
 }
 
 # Bucket for long term Argo logs storage, currently want no "delete after N days" rule.
 resource google_storage_bucket hca_argo_archive {
   provider = google-beta.target
-  name = "${local.dev_project_name}-argo-archive"
+  name     = "${local.dev_project_name}-argo-archive"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
   provider = google-beta.target
-  bucket =  google_storage_bucket.hca_argo_archive.name
+  bucket   = google_storage_bucket.hca_argo_archive.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_argo_runner_account.email}"
 }
 # Service accounts that use these buckets
@@ -106,26 +106,26 @@ module hca_dataflow_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "hca-dataflow-runner"
+  account_id   = "hca-dataflow-runner"
   display_name = "Service account to run HCA dataflow jobs"
-  vault_path = "${local.dev_vault_prefix}/service-accounts/hca-dataflow-runner"
-  roles = ["dataflow.worker"]
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dataflow-runner"
+  roles        = ["dataflow.worker"]
 }
 
 module hca_argo_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "hca-argo-runner"
+  account_id   = "hca-argo-runner"
   display_name = "Service account to run HCA's Argo workflow."
-  vault_path = "${local.dev_vault_prefix}/service-accounts/hca-argo-runner"
-  roles = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-argo-runner"
+  roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
 }
 
 data google_project current_project {
@@ -136,14 +136,14 @@ resource google_service_account_iam_binding hca_workload_identity_binding {
   provider = google-beta.target
 
   service_account_id = module.hca_argo_runner_account.id
-  role = "roles/iam.workloadIdentityUser"
-  members = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[hca-mvp/argo-runner]"]
+  role               = "roles/iam.workloadIdentityUser"
+  members            = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[hca-mvp/argo-runner]"]
 }
 
 resource google_service_account_iam_binding dataflow_runner_user_binding {
   provider = google-beta.target
 
   service_account_id = module.hca_dataflow_account.id
-  role = "roles/iam.serviceAccountUser"
-  members = ["serviceAccount:${module.hca_argo_runner_account.email}"]
+  role               = "roles/iam.serviceAccountUser"
+  members            = ["serviceAccount:${module.hca_argo_runner_account.email}"]
 }

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -103,7 +103,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 # Service accounts that use these buckets
 # sa w/permissions to use dataflow & bigquery
 module hca_dataflow_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target
@@ -116,7 +116,7 @@ module hca_dataflow_account {
 }
 
 module hca_argo_runner_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/cloudsql.tf
+++ b/environments/hca/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "../../../../templates/cloudsql"
+  source = "../../../templates/terraform/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca/terraform/cloudsql.tf
+++ b/environments/hca/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "./templates/cloudsql"
+  source = "../../../templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca/terraform/cloudsql.tf
+++ b/environments/hca/terraform/cloudsql.tf
@@ -2,19 +2,19 @@ module cloudsql {
   source = "../../../templates/terraform/cloudsql"
   providers = {
     google.target = google-beta.target
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
   name_prefix = "command-center"
-  cpu = 4
-  ram = 15360
+  cpu         = 4
+  ram         = 15360
   labels = {
-    app = "hca"
-    role = "database"
+    app   = "hca"
+    role  = "database"
     state = "active"
   }
-  db_names = ["argo"]
-  user_names = ["argo"]
+  db_names     = ["argo"]
+  user_names   = ["argo"]
   vault_prefix = local.dev_vault_prefix
   dependencies = module.enable_services
 }

--- a/environments/hca/terraform/cloudsql.tf
+++ b/environments/hca/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "../../templates/cloudsql"
+  source = "./templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca/terraform/cloudsql.tf
+++ b/environments/hca/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "/templates/cloudsql"
+  source = "../../templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca/terraform/cloudsql.tf
+++ b/environments/hca/terraform/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "../../../templates/cloudsql"
+  source = "../../../../templates/cloudsql"
   providers = {
     google.target = google-beta.target
     vault.target = vault.target

--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -1,16 +1,16 @@
 data google_dns_managed_zone dev_zone {
   provider = google-beta.dev-core
-  name = "monster-dev"
+  name     = "monster-dev"
 }
 
 module dns_names {
   source = "../../../templates/terraform/dns"
   providers = {
-    google.ip = google-beta.target,
+    google.ip  = google-beta.target,
     google.dns = google-beta.dev-core
   }
-  dependencies = [module.enable_services]
+  dependencies  = [module.enable_services]
   zone_gcp_name = data.google_dns_managed_zone.dev_zone.name
   zone_dns_name = data.google_dns_managed_zone.dev_zone.dns_name
-  dns_names = ["hca-argo", "hca-grafana"]
+  dns_names     = ["hca-argo", "hca-grafana"]
 }

--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone dev_zone {
 }
 
 module dns_names {
-  source = "../../../templates/dns"
+  source = "../../../../templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.dev-core

--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone dev_zone {
 }
 
 module dns_names {
-  source = "../../../../templates/dns"
+  source = "../../../templates/terraform/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.dev-core

--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone dev_zone {
 }
 
 module dns_names {
-  source = "./templates/dns"
+  source = "../../../templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.dev-core

--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone dev_zone {
 }
 
 module dns_names {
-  source = "/templates/dns"
+  source = "../../templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.dev-core

--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -4,7 +4,7 @@ data google_dns_managed_zone dev_zone {
 }
 
 module dns_names {
-  source = "../../templates/dns"
+  source = "./templates/dns"
   providers = {
     google.ip = google-beta.target,
     google.dns = google-beta.dev-core

--- a/environments/hca/terraform/ebi-bucket.tf
+++ b/environments/hca/terraform/ebi-bucket.tf
@@ -7,7 +7,7 @@ resource google_storage_bucket ebi_staging_bucket {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/ebi-bucket.tf
+++ b/environments/hca/terraform/ebi-bucket.tf
@@ -7,7 +7,7 @@ resource google_storage_bucket ebi_staging_bucket {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/ebi-bucket.tf
+++ b/environments/hca/terraform/ebi-bucket.tf
@@ -1,7 +1,7 @@
 # Staging bucket for EBI.
 resource google_storage_bucket ebi_staging_bucket {
   provider = google-beta.target
-  name = "${local.dev_project_name}-ebi-staging"
+  name     = "${local.dev_project_name}-ebi-staging"
   location = "US"
 }
 
@@ -10,33 +10,33 @@ module ebi_writer_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "ebi-staging-writer"
+  account_id   = "ebi-staging-writer"
   display_name = "Account used by EBI to interact with their staging bucket"
-  vault_path = "${local.dev_vault_prefix}/service-accounts/ebi-storage-writer"
-  roles = ["storagetransfer.user", "storagetransfer.viewer"]
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/ebi-storage-writer"
+  roles        = ["storagetransfer.user", "storagetransfer.viewer"]
 }
 
 # EBI is an admin on their bucket.
 resource google_storage_bucket_iam_member ebi_writer_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.ebi_staging_bucket.name
-  role = "roles/storage.objectAdmin"
-  member = "serviceAccount:${module.ebi_writer_account.email}"
+  bucket   = google_storage_bucket.ebi_staging_bucket.name
+  role     = "roles/storage.objectAdmin"
+  member   = "serviceAccount:${module.ebi_writer_account.email}"
 }
 
 # Rolando and Enrique are admin on their bucket
 resource google_storage_bucket_iam_member ebi_user_bucket_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.ebi_staging_bucket.name
+  bucket   = google_storage_bucket.ebi_staging_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
   for_each = toset(["enrique@ebi.ac.uk", "rolando@ebi.ac.uk"])
 
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "user:${each.value}"
 }
 
@@ -46,7 +46,7 @@ resource google_storage_bucket_iam_member tdr_reader_iam {
   for_each = toset([local.dev_repo_email, local.prod_repo_email, module.hca_dataflow_account.email])
 
   bucket = google_storage_bucket.ebi_staging_bucket.name
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${each.value}"
 }
 
@@ -60,6 +60,6 @@ resource google_storage_bucket_iam_member sts_iam {
   for_each = toset(["storage.legacyBucketReader", "storage.objectViewer", "storage.legacyBucketWriter"])
 
   bucket = google_storage_bucket.ebi_staging_bucket.name
-  role = "roles/${each.value}"
+  role   = "roles/${each.value}"
   member = "serviceAccount:${data.google_storage_transfer_project_service_account.sts_account.email}"
 }

--- a/environments/hca/terraform/ebi-bucket.tf
+++ b/environments/hca/terraform/ebi-bucket.tf
@@ -7,7 +7,7 @@ resource google_storage_bucket ebi_staging_bucket {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/ebi-bucket.tf
+++ b/environments/hca/terraform/ebi-bucket.tf
@@ -7,7 +7,7 @@ resource google_storage_bucket ebi_staging_bucket {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/ebi-bucket.tf
+++ b/environments/hca/terraform/ebi-bucket.tf
@@ -7,7 +7,7 @@ resource google_storage_bucket ebi_staging_bucket {
 
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "../../../templates/k8s-master"
+  source = "../../../../templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "../../../templates/k8s-node-pool"
+  source = "../../../../templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "../../../../templates/k8s-master"
+  source = "../../../templates/terraform/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "../../../../templates/k8s-node-pool"
+  source = "../../../templates/terraform/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -7,10 +7,10 @@ module master {
   }
   dependencies = [module.enable_services, module.k8s_network]
 
-  name = "hca-cluster"
+  name     = "hca-cluster"
   location = "us-central1-c"
 
-  network = module.k8s_network.network_link
+  network    = module.k8s_network.network_link
   subnetwork = module.k8s_network.subnet_links[0]
 
   restrict_master_access = false
@@ -25,16 +25,16 @@ module node_pool {
   }
   dependencies = [module.enable_services, module.master]
 
-  name = "hca-node-pool"
+  name        = "hca-node-pool"
   master_name = module.master.name
-  location = "us-central1-c"
+  location    = "us-central1-c"
 
-  node_count = 3
+  node_count   = 3
   machine_type = "n1-standard-2"
   disk_size_gb = 30
 
-  autoscaling = null
-  taints = null
+  autoscaling           = null
+  taints                = null
   service_account_email = module.hca_gke_runner_account.email
 }
 
@@ -43,11 +43,11 @@ module hca_gke_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "hca-gke-runner"
+  account_id   = "hca-gke-runner"
   display_name = "Service account to run GKE system pods"
-  vault_path = "${local.dev_vault_prefix}/service-accounts/gke-runner"
-  roles = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/gke-runner"
+  roles        = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
 }

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "./templates/k8s-master"
+  source = "../../../templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "./templates/k8s-node-pool"
+  source = "../../../templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "../../templates/k8s-master"
+  source = "./templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "../../templates/k8s-node-pool"
+  source = "./templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -1,7 +1,7 @@
 # k8s
 # Provision a cluster for running hca services.
 module master {
-  source = "/templates/k8s-master"
+  source = "../../templates/k8s-master"
   providers = {
     google.target = google-beta.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "/templates/k8s-node-pool"
+  source = "../../templates/k8s-node-pool"
   providers = {
     google.target = google-beta.target
   }
@@ -40,7 +40,7 @@ module node_pool {
 
 # gke service account
 module hca_gke_runner_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/networks.tf
+++ b/environments/hca/terraform/networks.tf
@@ -8,7 +8,7 @@ module k8s_network {
   name = "hca-network"
   subnets = [{
     region = "us-central1",
-    cidr = "10.0.0.0/22"
+    cidr   = "10.0.0.0/22"
   }]
   enable_flow_logs = false
 }

--- a/environments/hca/terraform/networks.tf
+++ b/environments/hca/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "../../templates/compute-network"
+  source = "./templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/networks.tf
+++ b/environments/hca/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "/templates/compute-network"
+  source = "../../templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/networks.tf
+++ b/environments/hca/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "../../../../templates/compute-network"
+  source = "../../../templates/terraform/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/networks.tf
+++ b/environments/hca/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "./templates/compute-network"
+  source = "../../../templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/networks.tf
+++ b/environments/hca/terraform/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "../../../templates/compute-network"
+  source = "../../../../templates/compute-network"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/provider.tf
+++ b/environments/hca/terraform/provider.tf
@@ -2,14 +2,14 @@ provider google-beta {
   alias = "target"
 
   project = local.dev_project_name
-  region = "us-central1"
+  region  = "us-central1"
 }
 
 provider google-beta {
   alias = "dev-core"
 
   project = "broad-dsp-monster-dev"
-  region = "us-central1"
+  region  = "us-central1"
 }
 
 provider vault {

--- a/environments/hca/terraform/provider.tf
+++ b/environments/hca/terraform/provider.tf
@@ -1,4 +1,5 @@
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   alias = "target"
 
   project = local.dev_project_name
@@ -6,6 +7,7 @@ provider google-beta {
 }
 
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   alias = "dev-core"
 
   project = "broad-dsp-monster-dev"

--- a/environments/hca/terraform/provider.tf
+++ b/environments/hca/terraform/provider.tf
@@ -1,5 +1,4 @@
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   alias = "target"
 
   project = local.dev_project_name
@@ -7,7 +6,6 @@ provider google-beta {
 }
 
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   alias = "dev-core"
 
   project = "broad-dsp-monster-dev"

--- a/environments/hca/terraform/services.tf
+++ b/environments/hca/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "../../../templates/api-services"
+  source = "../../../../templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/services.tf
+++ b/environments/hca/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "../../templates/api-services"
+  source = "./templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/services.tf
+++ b/environments/hca/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "./templates/api-services"
+  source = "../../../templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/services.tf
+++ b/environments/hca/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "../../../../templates/api-services"
+  source = "../../../templates/terraform/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/services.tf
+++ b/environments/hca/terraform/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "/templates/api-services"
+  source = "../../templates/api-services"
   providers = {
     google.target = google-beta.target
   }

--- a/environments/hca/terraform/sinks.tf
+++ b/environments/hca/terraform/sinks.tf
@@ -1,11 +1,11 @@
 resource google_storage_bucket logs {
   provider = google-beta.target
-  name  = "${local.dev_project_name}-error-logs"
+  name     = "${local.dev_project_name}-error-logs"
 }
 
 # Grant service account access to the storage bucket
 resource "google_storage_bucket_iam_member" "bucket-log-writer" {
-  provider = google-beta.target
+  provider   = google-beta.target
   bucket     = google_storage_bucket.logs.name
   role       = "roles/storage.objectCreator"
   member     = google_logging_project_sink.bucket-log-sink.writer_identity
@@ -13,7 +13,7 @@ resource "google_storage_bucket_iam_member" "bucket-log-writer" {
 }
 
 resource "google_logging_project_sink" "bucket-log-sink" {
-  provider = google-beta.target
+  provider               = google-beta.target
   name                   = "${local.dev_project_name}-gcs-log-sink"
   destination            = "storage.googleapis.com/${google_storage_bucket.logs.name}"
   filter                 = "resource.type=\"dataflow_step\" severity=ERROR jsonPayload.message : (\"SchemaValidationError\" OR \"FileMismatchError\" OR \"NoRegexPatternMatchError\" OR \"MissingPropertyError\")"

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -18,7 +18,7 @@ resource google_storage_bucket_iam_member test_bucket_iam {
 
 
 module hca_test_account {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -18,7 +18,7 @@ resource google_storage_bucket_iam_member test_bucket_iam {
 
 
 module hca_test_account {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -18,7 +18,7 @@ resource google_storage_bucket_iam_member test_bucket_iam {
 
 
 module hca_test_account {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -1,18 +1,18 @@
 // create test bucket
 resource google_storage_bucket test_bucket {
   provider = google-beta.target
-  name = "${local.dev_project_name}-test-storage"
+  name     = "${local.dev_project_name}-test-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member test_bucket_iam {
   provider = google-beta.target
-  bucket = google_storage_bucket.test_bucket.name
+  bucket   = google_storage_bucket.test_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.hca_test_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.hca_test_account.email}"
   depends_on = [module.hca_test_account.delay]
 }
 
@@ -21,11 +21,11 @@ module hca_test_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "hca-test-runner"
+  account_id   = "hca-test-runner"
   display_name = "Service account to run HCA tests"
-  vault_path = "${local.dev_vault_prefix}/service-accounts/hca-test-runner"
-  roles = ["dataflow.worker", "dataflow.admin"]
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-test-runner"
+  roles        = ["dataflow.worker", "dataflow.admin"]
 }

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -18,7 +18,7 @@ resource google_storage_bucket_iam_member test_bucket_iam {
 
 
 module hca_test_account {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -18,7 +18,7 @@ resource google_storage_bucket_iam_member test_bucket_iam {
 
 
 module hca_test_account {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.target,
     vault.target = vault.target

--- a/environments/hca/terraform/variables.tf
+++ b/environments/hca/terraform/variables.tf
@@ -1,8 +1,8 @@
 locals {
   dev_project_name = "broad-dsp-monster-hca-dev"
   dev_vault_prefix = "secret/dsde/monster/dev/ingest/hca"
-  dev_repo_email = "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"
+  dev_repo_email   = "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"
 
   prod_vault_prefix = "secret/dsde/monster/prod/ingest/hca"
-  prod_repo_email = "terra-data-repository@broad-datarepo-terra-prod.iam.gserviceaccount.com"
+  prod_repo_email   = "terra-data-repository@broad-datarepo-terra-prod.iam.gserviceaccount.com"
 }

--- a/environments/prod/terraform/backend.tf
+++ b/environments/prod/terraform/backend.tf
@@ -7,7 +7,6 @@
 ###
 terraform {
   backend "gcs" {
-    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "tfstate.json"
   }

--- a/environments/prod/terraform/backend.tf
+++ b/environments/prod/terraform/backend.tf
@@ -7,7 +7,7 @@
 ###
 terraform {
   backend "gcs" {
-    credentials = file("../../gcs_sa_key.json")
+    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "tfstate.json"
   }

--- a/environments/prod/terraform/backend.tf
+++ b/environments/prod/terraform/backend.tf
@@ -7,6 +7,7 @@
 ###
 terraform {
   backend "gcs" {
+    credentials = file("../../gcs_sa_key.json")
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "tfstate.json"
   }

--- a/environments/prod/terraform/backend.tf
+++ b/environments/prod/terraform/backend.tf
@@ -8,6 +8,6 @@
 terraform {
   backend "gcs" {
     bucket = "broad-dsp-monster-prod-terraform-state"
-    path = "tfstate.json"
+    path   = "tfstate.json"
   }
 }

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -1,4 +1,5 @@
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-prod"
   region = "us-central1"
   alias = "command-center"
@@ -9,12 +10,14 @@ provider vault {
 }
 
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-clingen-prod"
   region = "us-central1"
   alias = "clinvar"
 }
 
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-encode-prod"
   region = "us-west1"
   alias = "encode"

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "../../../../templates/monster-infrastructure"
+  source = "../../../templates/terraform/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -1,5 +1,4 @@
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-prod"
   region = "us-central1"
   alias = "command-center"
@@ -10,14 +9,12 @@ provider vault {
 }
 
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-clingen-prod"
   region = "us-central1"
   alias = "clinvar"
 }
 
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-encode-prod"
   region = "us-west1"
   alias = "encode"

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "../../../templates/monster-infrastructure"
+  source = "../../../../templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -1,7 +1,7 @@
 provider google-beta {
   project = "broad-dsp-monster-prod"
-  region = "us-central1"
-  alias = "command-center"
+  region  = "us-central1"
+  alias   = "command-center"
 }
 
 provider vault {
@@ -10,34 +10,34 @@ provider vault {
 
 provider google-beta {
   project = "broad-dsp-monster-clingen-prod"
-  region = "us-central1"
-  alias = "clinvar"
+  region  = "us-central1"
+  alias   = "clinvar"
 }
 
 provider google-beta {
   project = "broad-dsp-monster-encode-prod"
-  region = "us-west1"
-  alias = "encode"
+  region  = "us-west1"
+  alias   = "encode"
 }
 
 provider aws {
   region = "us-east-1"
-  alias = "encode"
+  alias  = "encode"
 }
 
 module monster_infrastructure {
   source = "../../../templates/terraform/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
-    vault.target = vault.command-center
-    google.clinvar = google-beta.clinvar
-    google.encode = google-beta.encode,
-    aws.encode = aws.encode
+    vault.target          = vault.command-center
+    google.clinvar        = google-beta.clinvar
+    google.encode         = google-beta.encode,
+    aws.encode            = aws.encode
   }
 
   is_production = true
-  cluster_size = 3
-  machine_type = "n1-standard-4"
+  cluster_size  = 3
+  machine_type  = "n1-standard-4"
   # 4 CPU, 15 GiB of RAM.
   db_tier = "db-custom-4-15360"
 }

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "./templates/monster-infrastructure"
+  source = "../../../templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "../../templates/monster-infrastructure"
+  source = "./templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -26,7 +26,7 @@ provider aws {
 }
 
 module monster_infrastructure {
-  source = "/templates/monster-infrastructure"
+  source = "../../templates/monster-infrastructure"
   providers = {
     google.command-center = google-beta.command-center
     vault.target = vault.command-center

--- a/environments/v2f-prod/terraform/backend.tf
+++ b/environments/v2f-prod/terraform/backend.tf
@@ -4,7 +4,7 @@
 ###
 terraform {
   backend "gcs" {
-    credentials = file("../../gcs_sa_key.json")
+    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "v2f.tfstate.json"
   }

--- a/environments/v2f-prod/terraform/backend.tf
+++ b/environments/v2f-prod/terraform/backend.tf
@@ -4,7 +4,6 @@
 ###
 terraform {
   backend "gcs" {
-    credentials = "../../gcs_sa_key.json"
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "v2f.tfstate.json"
   }

--- a/environments/v2f-prod/terraform/backend.tf
+++ b/environments/v2f-prod/terraform/backend.tf
@@ -5,6 +5,6 @@
 terraform {
   backend "gcs" {
     bucket = "broad-dsp-monster-prod-terraform-state"
-    path = "v2f.tfstate.json"
+    path   = "v2f.tfstate.json"
   }
 }

--- a/environments/v2f-prod/terraform/backend.tf
+++ b/environments/v2f-prod/terraform/backend.tf
@@ -4,6 +4,7 @@
 ###
 terraform {
   backend "gcs" {
+    credentials = file("../../gcs_sa_key.json")
     bucket = "broad-dsp-monster-prod-terraform-state"
     path = "v2f.tfstate.json"
   }

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -21,7 +21,7 @@ resource google_storage_bucket v2f_results_bucket {
 }
 
 module v2f_writer {
-  source = "../../../../templates/google-sa"
+  source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.v2f

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -21,7 +21,7 @@ resource google_storage_bucket v2f_results_bucket {
 }
 
 module v2f_writer {
-  source = "/templates/google-sa"
+  source = "../../templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.v2f

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -21,7 +21,7 @@ resource google_storage_bucket v2f_results_bucket {
 }
 
 module v2f_writer {
-  source = "../../../templates/google-sa"
+  source = "../../../../templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.v2f

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -1,12 +1,10 @@
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-v2f-prod"
   region = "us-central1"
   alias = "v2f"
 }
 
 provider google-beta {
-  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-dev"
   region = "us-central1"
   alias = "command-center"

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -21,7 +21,7 @@ resource google_storage_bucket v2f_results_bucket {
 }
 
 module v2f_writer {
-  source = "./templates/google-sa"
+  source = "../../../templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.v2f

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -21,7 +21,7 @@ resource google_storage_bucket v2f_results_bucket {
 }
 
 module v2f_writer {
-  source = "../../templates/google-sa"
+  source = "./templates/google-sa"
   providers = {
     google.target = google-beta.command-center,
     vault.target = vault.v2f

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -1,13 +1,13 @@
 provider google-beta {
   project = "broad-dsp-monster-v2f-prod"
-  region = "us-central1"
-  alias = "v2f"
+  region  = "us-central1"
+  alias   = "v2f"
 }
 
 provider google-beta {
   project = "broad-dsp-monster-dev"
-  region = "us-central1"
-  alias = "command-center"
+  region  = "us-central1"
+  alias   = "command-center"
 }
 
 provider vault {
@@ -16,7 +16,7 @@ provider vault {
 
 resource google_storage_bucket v2f_results_bucket {
   provider = google-beta.v2f
-  name = "variant-to-function-result-sets"
+  name     = "variant-to-function-result-sets"
   location = "US"
 }
 
@@ -24,13 +24,13 @@ module v2f_writer {
   source = "../../../templates/terraform/google-sa"
   providers = {
     google.target = google-beta.command-center,
-    vault.target = vault.v2f
+    vault.target  = vault.v2f
   }
 
-  account_id = "v2f-writer"
+  account_id   = "v2f-writer"
   display_name = " Service account to write V2F data to GCS"
-  vault_path = "secret/dsde/monster/prod/v2f/service-accounts/bucket-writer"
-  roles = []
+  vault_path   = "secret/dsde/monster/prod/v2f/service-accounts/bucket-writer"
+  roles        = []
 }
 
 data google_project command_center {
@@ -38,31 +38,31 @@ data google_project command_center {
 }
 
 resource google_storage_bucket_iam_member v2f_iam {
-  provider = google-beta.v2f
-  bucket = google_storage_bucket.v2f_results_bucket.name
-  role = "roles/storage.objectAdmin"
-  member = "serviceAccount:${module.v2f_writer.email}"
+  provider   = google-beta.v2f
+  bucket     = google_storage_bucket.v2f_results_bucket.name
+  role       = "roles/storage.objectAdmin"
+  member     = "serviceAccount:${module.v2f_writer.email}"
   depends_on = [module.v2f_writer.delay]
 }
 
 resource google_service_account_iam_binding v2f_binding_iam {
-  provider = google-beta.command-center
+  provider           = google-beta.command-center
   service_account_id = module.v2f_writer.id
-  role = "roles/iam.workloadIdentityUser"
+  role               = "roles/iam.workloadIdentityUser"
 
   members = ["serviceAccount:${data.google_project.command_center.name}.svc.id.goog[v2f/argo-runner]"]
 }
 
 resource google_storage_bucket_iam_member v2f_reader_iam {
   provider = google-beta.v2f
-  bucket = google_storage_bucket.v2f_results_bucket.name
-  role = "roles/storage.objectViewer"
-  member = "group:v2fcir@broadinstitute.org"
+  bucket   = google_storage_bucket.v2f_results_bucket.name
+  role     = "roles/storage.objectViewer"
+  member   = "group:v2fcir@broadinstitute.org"
 }
 
 resource google_storage_bucket_iam_member v2f_admin_iam {
   provider = google-beta.v2f
-  bucket = google_storage_bucket.v2f_results_bucket.name
-  role = "roles/storage.objectAdmin"
-  member = "user:schaluva@broadinstitute.org"
+  bucket   = google_storage_bucket.v2f_results_bucket.name
+  role     = "roles/storage.objectAdmin"
+  member   = "user:schaluva@broadinstitute.org"
 }

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -1,10 +1,12 @@
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-v2f-prod"
   region = "us-central1"
   alias = "v2f"
 }
 
 provider google-beta {
+  credentials = file("../../gcs_sa_key.json")
   project = "broad-dsp-monster-dev"
   region = "us-central1"
   alias = "command-center"

--- a/hack/apply-terraform
+++ b/hack/apply-terraform
@@ -38,10 +38,10 @@ function main () {
     -e VAULT_ADDR=${VAULT_ADDR}
     -v ${HOME}/.vault-token:/root/.vault-token
     # Terraform template paths
-    -v ${TF_TEMPLATES_PATH}:/templates
+    -v ${TF_TEMPLATES_PATH}:/${TF_TEMPLATES_PATH}
     # Terraform source paths
-    -v ${env_dir}:/env
-    -w /env/terraform
+    -v ${env_dir}:${env_dir}
+    -w ${env_dir}/terraform
     ${TERRAFORM}
   )
 

--- a/templates/terraform/api-services/main.tf
+++ b/templates/terraform/api-services/main.tf
@@ -1,20 +1,20 @@
 # Enable baseline APIs needed to use Terraform at all.
 resource google_project_service service_usage {
-  provider = google.target
-  service = "serviceusage.googleapis.com"
+  provider           = google.target
+  service            = "serviceusage.googleapis.com"
   disable_on_destroy = false
 }
 resource google_project_service cloud_resource_manager {
-  provider = google.target
-  service = "cloudresourcemanager.googleapis.com"
+  provider           = google.target
+  service            = "cloudresourcemanager.googleapis.com"
   disable_on_destroy = false
 }
 
 # Enable user-requested APIs.
 resource google_project_service services {
   provider = google.target
-  count = length(var.service_ids)
-  service = var.service_ids[count.index]
+  count    = length(var.service_ids)
+  service  = var.service_ids[count.index]
   depends_on = [
     google_project_service.service_usage,
     google_project_service.cloud_resource_manager

--- a/templates/terraform/api-services/variables.tf
+++ b/templates/terraform/api-services/variables.tf
@@ -1,4 +1,4 @@
 variable service_ids {
-  type = list(string)
+  type        = list(string)
   description = "IDs of Google APIs to enable in the target project."
 }

--- a/templates/terraform/aws-sa/main.tf
+++ b/templates/terraform/aws-sa/main.tf
@@ -1,15 +1,15 @@
 # Generate the new account.
 resource aws_iam_user user {
   provider = aws.target
-  name = var.account_id
+  name     = var.account_id
 }
 resource aws_iam_access_key user_key {
   provider = aws.target
-  user = aws_iam_user.user.name
+  user     = aws_iam_user.user.name
 }
 resource vault_generic_secret user_secret {
-  provider = vault.target
-  path = var.vault_path
+  provider  = vault.target
+  path      = var.vault_path
   data_json = <<DATA
 {
   "access_key_id": "${aws_iam_access_key.user_key.id}",
@@ -23,15 +23,15 @@ data aws_iam_policy_document user_policy {
   dynamic "statement" {
     for_each = var.iam_policy
     content {
-      sid = statement.value["subject_id"]
-      actions = statement.value["actions"]
+      sid       = statement.value["subject_id"]
+      actions   = statement.value["actions"]
       resources = statement.value["resources"]
     }
   }
 }
 resource aws_iam_user_policy user_policy {
   provider = aws.target
-  name = "${var.account_id}-policy"
-  policy = data.aws_iam_policy_document.user_policy.json
-  user = aws_iam_user.user.name
+  name     = "${var.account_id}-policy"
+  policy   = data.aws_iam_policy_document.user_policy.json
+  user     = aws_iam_user.user.name
 }

--- a/templates/terraform/aws-sa/variables.tf
+++ b/templates/terraform/aws-sa/variables.tf
@@ -1,14 +1,14 @@
 variable account_id {
-  type = string
+  type        = string
   description = "Name to assign to the new account."
 }
 
 variable vault_path {
-  type = string
+  type        = string
   description = "Vault path where the new account's GCS key should be stored."
 }
 
 variable iam_policy {
-  type = list(object({subject_id = string, actions = list(string), resources = list(string)}))
+  type        = list(object({ subject_id = string, actions = list(string), resources = list(string) }))
   description = "AWS policies to apply to the new account."
 }

--- a/templates/terraform/cloudsql/main.tf
+++ b/templates/terraform/cloudsql/main.tf
@@ -79,7 +79,7 @@ resource google_sql_database db {
 
 # Create a service account for accessing the instance.
 module proxy_sa {
-  source = "..//google-sa"
+  source = "../google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/cloudsql/main.tf
+++ b/templates/terraform/cloudsql/main.tf
@@ -9,30 +9,30 @@ resource random_id cloudsql_random_id {
 # NOTE: We might need multiple instances in prod, if it turns out there's too
 # much resource contention sharing a single instance.
 resource google_sql_database_instance postgres {
-  provider = google.target
+  provider   = google.target
   depends_on = [var.dependencies]
 
-  name = "${var.name_prefix}-postgres-${random_id.cloudsql_random_id.hex}"
+  name             = "${var.name_prefix}-postgres-${random_id.cloudsql_random_id.hex}"
   database_version = var.postgres_version
 
   settings {
     activation_policy = "ALWAYS"
-    pricing_plan = "PER_USE"
-    replication_type = "SYNCHRONOUS"
-    tier = "db-custom-${var.cpu}-${var.ram}"
-    user_labels = var.labels
+    pricing_plan      = "PER_USE"
+    replication_type  = "SYNCHRONOUS"
+    tier              = "db-custom-${var.cpu}-${var.ram}"
+    user_labels       = var.labels
 
     backup_configuration {
       binary_log_enabled = false
-      enabled = true
-      start_time = "06:00"
+      enabled            = true
+      start_time         = "06:00"
     }
 
     ip_configuration {
       ipv4_enabled = true
-      require_ssl = true
+      require_ssl  = true
       authorized_networks {
-        name = "Broad"
+        name  = "Broad"
         value = "69.173.64.0/18"
       }
     }
@@ -49,7 +49,7 @@ resource google_sql_user db_user {
   for_each = toset(var.user_names)
 
   provider = google.target
-  name = each.value
+  name     = each.value
   password = random_id.db_password[each.value].hex
   instance = google_sql_database_instance.postgres.name
 }
@@ -57,8 +57,8 @@ resource google_sql_user db_user {
 resource vault_generic_secret postgres_user {
   for_each = toset(var.user_names)
 
-  provider = vault.target
-  path = "${var.vault_prefix}/cloudsql/users/${each.value}"
+  provider  = vault.target
+  path      = "${var.vault_prefix}/cloudsql/users/${each.value}"
   data_json = <<EOT
 {
   "password": "${random_id.db_password[each.value].hex}"
@@ -69,11 +69,11 @@ EOT
 resource google_sql_database db {
   for_each = toset(var.db_names)
 
-  provider = google.target
-  name = each.value
-  instance = google_sql_database_instance.postgres.name
-  charset = "UTF8"
-  collation = "en_US.UTF8"
+  provider   = google.target
+  name       = each.value
+  instance   = google_sql_database_instance.postgres.name
+  charset    = "UTF8"
+  collation  = "en_US.UTF8"
   depends_on = [google_sql_user.db_user]
 }
 
@@ -82,13 +82,13 @@ module proxy_sa {
   source = "../google-sa"
   providers = {
     google.target = google.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "${var.name_prefix}-proxy-runner"
+  account_id   = "${var.name_prefix}-proxy-runner"
   display_name = "CloudSQL proxy account"
-  vault_path = "${var.vault_prefix}/service-accounts/${var.name_prefix}-proxy-runner"
-  roles = ["cloudsql.client"]
+  vault_path   = "${var.vault_prefix}/service-accounts/${var.name_prefix}-proxy-runner"
+  roles        = ["cloudsql.client"]
   dependencies = var.dependencies
 }
 
@@ -96,7 +96,7 @@ module proxy_sa {
 resource vault_generic_secret postgres_connection_name {
   provider = vault.target
 
-  path = "${var.vault_prefix}/cloudsql/instance"
+  path      = "${var.vault_prefix}/cloudsql/instance"
   data_json = <<EOT
 {
   "name": "${google_sql_database_instance.postgres.name}",

--- a/templates/terraform/cloudsql/main.tf
+++ b/templates/terraform/cloudsql/main.tf
@@ -79,7 +79,7 @@ resource google_sql_database db {
 
 # Create a service account for accessing the instance.
 module proxy_sa {
-  source = ".//google-sa"
+  source = "..//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/cloudsql/main.tf
+++ b/templates/terraform/cloudsql/main.tf
@@ -79,7 +79,7 @@ resource google_sql_database db {
 
 # Create a service account for accessing the instance.
 module proxy_sa {
-  source = "/templates/google-sa"
+  source = ".//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/cloudsql/variables.tf
+++ b/templates/terraform/cloudsql/variables.tf
@@ -1,46 +1,46 @@
 variable name_prefix {
-  type = string
+  type        = string
   description = "Prefix to add before cloudSQL resource names."
 }
 
 variable postgres_version {
-  type = string
+  type        = string
   description = "The version of PostgreSQL to use."
-  default = "POSTGRES_9_6"
+  default     = "POSTGRES_9_6"
 }
 
 variable cpu {
-  type = number
+  type        = number
   description = "Number of processors allocated to the instance."
 }
 
 variable ram {
-  type = number
+  type        = number
   description = "Memory allocated to the instance in MiB."
 }
 
 variable labels {
-  type = map(string)
+  type        = map(string)
   description = "A set of key/value user label pairs to assign to the instance."
 }
 
 variable db_names {
-  type = list(string)
+  type        = list(string)
   description = "List of database names."
 }
 
 variable user_names {
-  type = list(string)
+  type        = list(string)
   description = "List of user names."
 }
 
 variable vault_prefix {
-  type = string
+  type        = string
   description = "Path to prepend before a vault path for this module's secrets."
 }
 
 variable dependencies {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "..//cloudsql"
+  source = "../cloudsql"
   providers = {
     google.target = google.target
     vault.target = vault.target

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = ".//cloudsql"
+  source = "..//cloudsql"
   providers = {
     google.target = google.target
     vault.target = vault.target

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -2,19 +2,19 @@ module cloudsql {
   source = "../cloudsql"
   providers = {
     google.target = google.target
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
   name_prefix = "command-center"
-  cpu = 4
-  ram = 15360
+  cpu         = 4
+  ram         = 15360
   labels = {
-    app = "command-center"
-    role = "database"
+    app   = "command-center"
+    role  = "database"
     state = "active"
   }
-  db_names = ["argo"]
-  user_names = ["argo"]
+  db_names     = ["argo"]
+  user_names   = ["argo"]
   vault_prefix = local.vault_prefix
   dependencies = module.enable_services
 }

--- a/templates/terraform/command-center-project/cloudsql.tf
+++ b/templates/terraform/command-center-project/cloudsql.tf
@@ -1,5 +1,5 @@
 module cloudsql {
-  source = "/templates/cloudsql"
+  source = ".//cloudsql"
   providers = {
     google.target = google.target
     vault.target = vault.target

--- a/templates/terraform/command-center-project/dns.tf
+++ b/templates/terraform/command-center-project/dns.tf
@@ -11,7 +11,7 @@ resource google_dns_managed_zone dns_zone {
 }
 
 module dns_names {
-  source = ".//dns"
+  source = "..//dns"
   providers = {
     google.ip = google.target,
     google.dns = google.target

--- a/templates/terraform/command-center-project/dns.tf
+++ b/templates/terraform/command-center-project/dns.tf
@@ -11,7 +11,7 @@ resource google_dns_managed_zone dns_zone {
 }
 
 module dns_names {
-  source = "..//dns"
+  source = "../dns"
   providers = {
     google.ip = google.target,
     google.dns = google.target

--- a/templates/terraform/command-center-project/dns.tf
+++ b/templates/terraform/command-center-project/dns.tf
@@ -11,7 +11,7 @@ resource google_dns_managed_zone dns_zone {
 }
 
 module dns_names {
-  source = "/templates/dns"
+  source = ".//dns"
   providers = {
     google.ip = google.target,
     google.dns = google.target

--- a/templates/terraform/command-center-project/dns.tf
+++ b/templates/terraform/command-center-project/dns.tf
@@ -6,18 +6,18 @@
 ###
 resource google_dns_managed_zone dns_zone {
   provider = google.target
-  name = local.dns_zone_name
+  name     = local.dns_zone_name
   dns_name = "${local.dns_zone_name}.broadinstitute.org."
 }
 
 module dns_names {
   source = "../dns"
   providers = {
-    google.ip = google.target,
+    google.ip  = google.target,
     google.dns = google.target
   }
-  dependencies = [module.enable_services]
+  dependencies  = [module.enable_services]
   zone_gcp_name = google_dns_managed_zone.dns_zone.name
   zone_dns_name = google_dns_managed_zone.dns_zone.dns_name
-  dns_names = ["argo","grafana"]
+  dns_names     = ["argo", "grafana"]
 }

--- a/templates/terraform/command-center-project/k8s.tf
+++ b/templates/terraform/command-center-project/k8s.tf
@@ -7,10 +7,10 @@ module master {
   }
   dependencies = [module.enable_services, module.k8s_network]
 
-  name = "command-center-cluster"
+  name     = "command-center-cluster"
   location = "us-central1-c"
 
-  network = module.k8s_network.network_link
+  network    = module.k8s_network.network_link
   subnetwork = module.k8s_network.subnet_links[0]
 
   restrict_master_access = var.is_production
@@ -25,15 +25,15 @@ module node_pool {
   }
   dependencies = [module.enable_services, module.master]
 
-  name = "command-center-node-pool"
+  name        = "command-center-node-pool"
   master_name = module.master.name
-  location = "us-central1-c"
+  location    = "us-central1-c"
 
-  node_count = var.k8s_cluster_size
+  node_count   = var.k8s_cluster_size
   machine_type = var.k8s_machine_type
   disk_size_gb = 30
 
-  autoscaling = null
-  taints = null
+  autoscaling           = null
+  taints                = null
   service_account_email = module.command_center_gke_runner_account.email
 }

--- a/templates/terraform/command-center-project/k8s.tf
+++ b/templates/terraform/command-center-project/k8s.tf
@@ -1,7 +1,7 @@
 # Provision a cluster for running "command center" services.
 # For example, this cluster will run Airflow, Argo CD, and the Argo controllers.
 module master {
-  source = "..//k8s-master"
+  source = "../k8s-master"
   providers = {
     google.target = google.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "..//k8s-node-pool"
+  source = "../k8s-node-pool"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/k8s.tf
+++ b/templates/terraform/command-center-project/k8s.tf
@@ -1,7 +1,7 @@
 # Provision a cluster for running "command center" services.
 # For example, this cluster will run Airflow, Argo CD, and the Argo controllers.
 module master {
-  source = "/templates/k8s-master"
+  source = ".//k8s-master"
   providers = {
     google.target = google.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = "/templates/k8s-node-pool"
+  source = ".//k8s-node-pool"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/k8s.tf
+++ b/templates/terraform/command-center-project/k8s.tf
@@ -1,7 +1,7 @@
 # Provision a cluster for running "command center" services.
 # For example, this cluster will run Airflow, Argo CD, and the Argo controllers.
 module master {
-  source = ".//k8s-master"
+  source = "..//k8s-master"
   providers = {
     google.target = google.target
   }
@@ -19,7 +19,7 @@ module master {
 }
 
 module node_pool {
-  source = ".//k8s-node-pool"
+  source = "..//k8s-node-pool"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/networks.tf
+++ b/templates/terraform/command-center-project/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = ".//compute-network"
+  source = "..//compute-network"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/networks.tf
+++ b/templates/terraform/command-center-project/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "..//compute-network"
+  source = "../compute-network"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/networks.tf
+++ b/templates/terraform/command-center-project/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "/templates/compute-network"
+  source = ".//compute-network"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/networks.tf
+++ b/templates/terraform/command-center-project/networks.tf
@@ -8,7 +8,7 @@ module k8s_network {
   name = "command-center-network"
   subnets = [{
     region = "us-central1",
-    cidr = "10.0.0.0/22"
+    cidr   = "10.0.0.0/22"
   }]
   enable_flow_logs = var.is_production
 }

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -1,5 +1,5 @@
 module command_center_gke_runner_account {
-  source = "..//google-sa"
+  source = "../google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target
@@ -12,7 +12,7 @@ module command_center_gke_runner_account {
 }
 
 module clinvar_argo_runner_account {
-  source = "..//google-sa"
+  source = "../google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target
@@ -25,7 +25,7 @@ module clinvar_argo_runner_account {
 }
 
 module encode_argo_runner_account {
-  source = "..//google-sa"
+  source = "../google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -1,5 +1,5 @@
 module command_center_gke_runner_account {
-  source = ".//google-sa"
+  source = "..//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target
@@ -12,7 +12,7 @@ module command_center_gke_runner_account {
 }
 
 module clinvar_argo_runner_account {
-  source = ".//google-sa"
+  source = "..//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target
@@ -25,7 +25,7 @@ module clinvar_argo_runner_account {
 }
 
 module encode_argo_runner_account {
-  source = ".//google-sa"
+  source = "..//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -2,39 +2,39 @@ module command_center_gke_runner_account {
   source = "../google-sa"
   providers = {
     google.target = google.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "command-center-gke-runner"
+  account_id   = "command-center-gke-runner"
   display_name = "Service account to run GKE system pods"
-  vault_path = "${local.vault_prefix}/service-accounts/gke-runner"
-  roles = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
+  vault_path   = "${local.vault_prefix}/service-accounts/gke-runner"
+  roles        = ["logging.logWriter", "monitoring.metricWriter", "monitoring.viewer"]
 }
 
 module clinvar_argo_runner_account {
   source = "../google-sa"
   providers = {
     google.target = google.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "clinvar-argo-runner"
+  account_id   = "clinvar-argo-runner"
   display_name = "Service account to run ClinVar's Argo workflow."
-  vault_path = "${local.vault_prefix}/service-accounts/clinvar-argo-runner"
-  roles = ["container.developer"]
+  vault_path   = "${local.vault_prefix}/service-accounts/clinvar-argo-runner"
+  roles        = ["container.developer"]
 }
 
 module encode_argo_runner_account {
   source = "../google-sa"
   providers = {
     google.target = google.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "encode-argo-runner"
+  account_id   = "encode-argo-runner"
   display_name = "Service account to run Encode's Argo workflow."
-  vault_path = "${local.vault_prefix}/service-accounts/encode-argo-runner"
-  roles = ["container.developer"]
+  vault_path   = "${local.vault_prefix}/service-accounts/encode-argo-runner"
+  roles        = ["container.developer"]
 }
 
 data google_project current_project {
@@ -45,14 +45,14 @@ resource google_service_account_iam_binding clinvar_workload_identity_binding {
   provider = google.target
 
   service_account_id = module.clinvar_argo_runner_account.id
-  role = "roles/iam.workloadIdentityUser"
-  members = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[clinvar/argo-runner]"]
+  role               = "roles/iam.workloadIdentityUser"
+  members            = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[clinvar/argo-runner]"]
 }
 
 resource google_service_account_iam_binding encode_workload_identity_binding {
   provider = google.target
 
   service_account_id = module.encode_argo_runner_account.id
-  role = "roles/iam.workloadIdentityUser"
-  members = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[encode/argo-runner]"]
+  role               = "roles/iam.workloadIdentityUser"
+  members            = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[encode/argo-runner]"]
 }

--- a/templates/terraform/command-center-project/service-accounts.tf
+++ b/templates/terraform/command-center-project/service-accounts.tf
@@ -1,5 +1,5 @@
 module command_center_gke_runner_account {
-  source = "/templates/google-sa"
+  source = ".//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target
@@ -12,7 +12,7 @@ module command_center_gke_runner_account {
 }
 
 module clinvar_argo_runner_account {
-  source = "/templates/google-sa"
+  source = ".//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target
@@ -25,7 +25,7 @@ module clinvar_argo_runner_account {
 }
 
 module encode_argo_runner_account {
-  source = "/templates/google-sa"
+  source = ".//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/command-center-project/services.tf
+++ b/templates/terraform/command-center-project/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "..//api-services"
+  source = "../api-services"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/services.tf
+++ b/templates/terraform/command-center-project/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "/templates/api-services"
+  source = ".//api-services"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/services.tf
+++ b/templates/terraform/command-center-project/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = ".//api-services"
+  source = "..//api-services"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/command-center-project/variables.tf
+++ b/templates/terraform/command-center-project/variables.tf
@@ -1,24 +1,24 @@
 variable is_production {
-  type = bool
+  type        = bool
   description = "If true, production-level logging etc. will be enabled"
 }
 
 variable k8s_cluster_size {
-  type = number
+  type        = number
   description = "Number of nodes to run in the GKE cluster."
 }
 
 variable k8s_machine_type {
-  type = string
+  type        = string
   description = "Machine type to use in the GKE cluster."
 }
 
 variable db_tier {
-  type = string
+  type        = string
   description = "Machine tier for the Cloud SQL proxy instance backing command-center services."
 }
 
 locals {
-  vault_prefix = "secret/dsde/monster/${var.is_production ? "prod" : "dev"}/command-center"
+  vault_prefix  = "secret/dsde/monster/${var.is_production ? "prod" : "dev"}/command-center"
   dns_zone_name = "monster-${var.is_production ? "prod" : "dev"}"
 }

--- a/templates/terraform/command-center-project/version.tf
+++ b/templates/terraform/command-center-project/version.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 3.2.0"
+    google      = "~> 3.2.0"
     google-beta = "~> 3.2.0"
   }
 }

--- a/templates/terraform/command-center-project/version.tf
+++ b/templates/terraform/command-center-project/version.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google      = "~> 3.2.0"
-    google-beta = "~> 3.2.0"
+    google      = "~> 3.50.0"
+    google-beta = "~> 3.50.0"
   }
 }

--- a/templates/terraform/compute-network/main.tf
+++ b/templates/terraform/compute-network/main.tf
@@ -1,9 +1,9 @@
 # Create the top-level network.
 resource google_compute_network network {
-  provider = google.target
-  name = var.name
+  provider                = google.target
+  name                    = var.name
   auto_create_subnetworks = false
-  depends_on = [var.dependencies]
+  depends_on              = [var.dependencies]
 }
 
 # Create subnetworks under the main network.
@@ -11,19 +11,19 @@ resource google_compute_network network {
 # names only need to be unique per parent network/region.
 resource google_compute_subnetwork subnetworks {
   provider = google.target
-  count = length(var.subnets)
+  count    = length(var.subnets)
 
-  name = var.name
-  network = google_compute_network.network.self_link
-  ip_cidr_range = var.subnets[count.index].cidr
+  name                     = var.name
+  network                  = google_compute_network.network.self_link
+  ip_cidr_range            = var.subnets[count.index].cidr
   private_ip_google_access = true
 
   dynamic "log_config" {
     for_each = var.enable_flow_logs ? ["Placeholder to force one iteration"] : []
     content {
       aggregation_interval = "INTERVAL_10_MIN"
-      flow_sampling = 0.5
-      metadata = "INCLUDE_ALL_METADATA"
+      flow_sampling        = 0.5
+      metadata             = "INCLUDE_ALL_METADATA"
     }
   }
 }
@@ -32,24 +32,24 @@ resource google_compute_subnetwork subnetworks {
 # can talk to the Internet (e.g. to pull Docker images from DockerHub).
 resource google_compute_router router {
   provider = google.target
-  name = "${var.name}-router"
-  network = google_compute_network.network.self_link
+  name     = "${var.name}-router"
+  network  = google_compute_network.network.self_link
 
   bgp {
     asn = 64514
   }
 }
 resource google_compute_address nat_addresses {
-  provider = google.target
-  count = 2
-  name = "${var.name}-nat-${count.index}"
+  provider   = google.target
+  count      = 2
+  name       = "${var.name}-nat-${count.index}"
   depends_on = [var.dependencies]
 }
 resource google_compute_router_nat nat {
-  provider = google.target
-  name = "${var.name}-nat"
-  router = google_compute_router.router.name
-  nat_ips = google_compute_address.nat_addresses[*].self_link
-  nat_ip_allocate_option = "MANUAL_ONLY"
+  provider                           = google.target
+  name                               = "${var.name}-nat"
+  router                             = google_compute_router.router.name
+  nat_ips                            = google_compute_address.nat_addresses[*].self_link
+  nat_ip_allocate_option             = "MANUAL_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }

--- a/templates/terraform/compute-network/variables.tf
+++ b/templates/terraform/compute-network/variables.tf
@@ -1,18 +1,18 @@
 variable dependencies {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
 }
 
 variable name {
-  type = string
+  type        = string
   description = "Name to assign to the network and its subnets"
 }
 
 variable subnets {
   type = list(object({
     region = string,
-    cidr = string
+    cidr   = string
   }))
 }
 

--- a/templates/terraform/dns/main.tf
+++ b/templates/terraform/dns/main.tf
@@ -1,8 +1,8 @@
 resource google_compute_global_address global_ip_address {
   for_each = toset(var.dns_names)
 
-  provider = google.ip
-  name = "${each.value}-ip"
+  provider   = google.ip
+  name       = "${each.value}-ip"
   depends_on = [var.dependencies]
 }
 
@@ -10,24 +10,24 @@ resource google_dns_record_set a_dns {
   for_each = toset(var.dns_names)
 
   provider = google.dns
-  type = "A"
-  ttl = "300"
+  type     = "A"
+  ttl      = "300"
 
   managed_zone = var.zone_gcp_name
-  name = "${each.value}-global.${var.zone_dns_name}"
-  rrdatas = [google_compute_global_address.global_ip_address[each.value].address]
-  depends_on = [var.dependencies]
+  name         = "${each.value}-global.${var.zone_dns_name}"
+  rrdatas      = [google_compute_global_address.global_ip_address[each.value].address]
+  depends_on   = [var.dependencies]
 }
 
 resource google_dns_record_set cname_dns {
   for_each = toset(var.dns_names)
 
   provider = google.dns
-  type = "CNAME"
-  ttl = "300"
+  type     = "CNAME"
+  ttl      = "300"
 
   managed_zone = var.zone_gcp_name
-  name = "${each.value}.${var.zone_dns_name}"
-  rrdatas = [google_dns_record_set.a_dns[each.value].name]
-  depends_on = [var.dependencies]
+  name         = "${each.value}.${var.zone_dns_name}"
+  rrdatas      = [google_dns_record_set.a_dns[each.value].name]
+  depends_on   = [var.dependencies]
 }

--- a/templates/terraform/dns/variables.tf
+++ b/templates/terraform/dns/variables.tf
@@ -1,20 +1,20 @@
 variable dns_names {
-  type = list(string)
+  type        = list(string)
   description = "List of DNS names to generate global IP addresses, A-records, and CNAME-records for."
 }
 
 variable dependencies {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
 }
 
 variable zone_gcp_name {
-  type = string
+  type        = string
   description = "GCP name for the managed DNS zone to generate records within."
 }
 
 variable zone_dns_name {
-  type = string
+  type        = string
   description = "DNS name of the zone to generate records within."
 }

--- a/templates/terraform/google-sa/main.tf
+++ b/templates/terraform/google-sa/main.tf
@@ -1,21 +1,21 @@
 # a service account
 resource google_service_account sa {
-  provider = google.target
-  account_id = var.account_id
+  provider     = google.target
+  account_id   = var.account_id
   display_name = var.display_name
-  depends_on = [var.dependencies]
+  depends_on   = [var.dependencies]
 }
 
 # a key associated with the service account
 resource google_service_account_key sa_key {
-  provider = google.target
+  provider           = google.target
   service_account_id = google_service_account.sa.name
 }
 
 # a vault secret containing the JSON key for the service account
 resource vault_generic_secret sa_secret {
-  provider = vault.target
-  path = var.vault_path
+  provider  = vault.target
+  path      = var.vault_path
   data_json = <<EOT
 {
   "key": ${jsonencode(base64decode(google_service_account_key.sa_key.private_key))}
@@ -39,9 +39,9 @@ resource null_resource sa_delay {
 resource google_project_iam_member sa_iam {
   for_each = toset(var.roles)
 
-  provider = google.target
+  provider   = google.target
   depends_on = [null_resource.sa_delay]
 
-  role = "roles/${each.value}"
+  role   = "roles/${each.value}"
   member = "serviceAccount:${google_service_account.sa.email}"
 }

--- a/templates/terraform/google-sa/variables.tf
+++ b/templates/terraform/google-sa/variables.tf
@@ -1,27 +1,27 @@
 variable account_id {
-  type = string
+  type        = string
   description = "Name to assign to the new account."
 }
 
 variable display_name {
-  type = string
+  type        = string
   description = "Display name to assign to the new account."
-  default = null
+  default     = null
 }
 
 variable vault_path {
-  type = string
+  type        = string
   description = "Vault path where the new account's GCS key should be stored."
 }
 
 variable roles {
-  type = list(string)
+  type        = list(string)
   description = "A list of roles for the service account to have."
-  default = []
+  default     = []
 }
 
 variable dependencies {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
 }

--- a/templates/terraform/k8s-master/main.tf
+++ b/templates/terraform/k8s-master/main.tf
@@ -1,6 +1,6 @@
 # Needed for getting the ID of the project backing the k8s resource.
 data google_project project {
-  provider = google-beta.target
+  provider = google.target
 }
 
 # Create the GKE master.

--- a/templates/terraform/k8s-master/main.tf
+++ b/templates/terraform/k8s-master/main.tf
@@ -9,11 +9,11 @@ data google_project project {
 resource google_container_cluster master {
   provider = google.target
 
-  name = var.name
-  location = var.location
+  name       = var.name
+  location   = var.location
   depends_on = [var.dependencies]
 
-  network = var.network
+  network    = var.network
   subnetwork = var.subnetwork
 
   # CIS compliance: stackdriver logging
@@ -39,7 +39,7 @@ resource google_container_cluster master {
   # Silly, but necessary to have a default pool of 0 nodes. This allows the node definition to be handled cleanly
   # in a separate file
   remove_default_node_pool = true
-  initial_node_count = 1
+  initial_node_count       = 1
 
   # CIS compliance: disable legacy Auth
   enable_legacy_abac = false
@@ -64,7 +64,7 @@ resource google_container_cluster master {
     # According to trial and error, setting these values to null
     # lets Google derive values that actually work.
     # Otherwise you'll end up flipping a table trying to set things manually.
-    cluster_ipv4_cidr_block = null
+    cluster_ipv4_cidr_block  = null
     services_ipv4_cidr_block = null
   }
 
@@ -79,9 +79,9 @@ resource google_container_cluster master {
 
   # OMISSION: CIS compliance: Enable Private Cluster
   private_cluster_config {
-    enable_private_nodes = true
+    enable_private_nodes    = true
     enable_private_endpoint = false
-    master_ipv4_cidr_block = "10.0.82.0/28"
+    master_ipv4_cidr_block  = "10.0.82.0/28"
   }
 
   dynamic "master_authorized_networks_config" {
@@ -106,24 +106,24 @@ resource google_container_cluster master {
 locals {
   # Inspired by https://ahmet.im/blog/authenticating-to-gke-without-gcloud/
   kubeconfig = {
-    apiVersion = "v1",
-    kind = "Config",
+    apiVersion      = "v1",
+    kind            = "Config",
     current-context = "context",
     contexts = [{
       name = "context",
       context = {
         cluster = google_container_cluster.master.name,
-        user = "local-user"
+        user    = "local-user"
       }
     }],
     users = [{
       name = "local-user",
-      user = {auth-provider = {name = "gcp"}}
+      user = { auth-provider = { name = "gcp" } }
     }],
     clusters = [{
       name = google_container_cluster.master.name,
       cluster = {
-        server = "https://${google_container_cluster.master.endpoint}",
+        server                     = "https://${google_container_cluster.master.endpoint}",
         certificate-authority-data = google_container_cluster.master.master_auth[0].cluster_ca_certificate
       }
     }]
@@ -131,7 +131,7 @@ locals {
 }
 
 resource vault_generic_secret master_secrets {
-  path = var.vault_path
+  path      = var.vault_path
   data_json = <<EOT
 {
   "kubeconfig": ${jsonencode(jsonencode(local.kubeconfig))}

--- a/templates/terraform/k8s-master/main.tf
+++ b/templates/terraform/k8s-master/main.tf
@@ -1,6 +1,6 @@
 # Needed for getting the ID of the project backing the k8s resource.
 data google_project project {
-  provider = google.target
+  provider = google-beta.target
 }
 
 # Create the GKE master.

--- a/templates/terraform/k8s-master/provider.tf
+++ b/templates/terraform/k8s-master/provider.tf
@@ -1,3 +1,3 @@
-provider google {
+provider google-beta {
   alias = "target"
 }

--- a/templates/terraform/k8s-master/provider.tf
+++ b/templates/terraform/k8s-master/provider.tf
@@ -1,3 +1,3 @@
-provider google-beta {
+provider google {
   alias = "target"
 }

--- a/templates/terraform/k8s-master/variables.tf
+++ b/templates/terraform/k8s-master/variables.tf
@@ -1,16 +1,16 @@
 variable dependencies {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
 }
 
 variable name {
-  type = string
+  type        = string
   description = "Name to assign to the master / GKE cluster."
 }
 
 variable location {
-  type = string
+  type        = string
   description = "Zone or region to host the cluster. NOTE: passing a region here will give you a regional cluster with 3x the number of nodes."
 }
 
@@ -23,11 +23,11 @@ variable subnetwork {
 }
 
 variable restrict_master_access {
-  type = bool
+  type        = bool
   description = "If true, access to the control plane will be restricted to only Broad IPs"
 }
 
 variable vault_path {
-  type = string
+  type        = string
   description = "Path in Vault where secrets for the master should be stored."
 }

--- a/templates/terraform/k8s-node-pool/main.tf
+++ b/templates/terraform/k8s-node-pool/main.tf
@@ -1,11 +1,11 @@
 # Create a GKE node pool, attached to an existing master.
 resource google_container_node_pool pool {
-  provider   = google.target
+  provider = google.target
 
   depends_on = [var.dependencies]
-  name = var.name
-  location = var.location
-  cluster = var.master_name
+  name       = var.name
+  location   = var.location
+  cluster    = var.master_name
   # node_count must be set to null if autoscaling is used
   node_count = var.node_count
 
@@ -27,22 +27,22 @@ resource google_container_node_pool pool {
   }
 
   upgrade_settings {
-    max_surge = 1
+    max_surge       = 1
     max_unavailable = 0
   }
 
   node_config {
     # CIS compliance: COS image
-    image_type = "COS"
-    machine_type = var.machine_type
-    disk_size_gb = var.disk_size_gb
+    image_type      = "COS"
+    machine_type    = var.machine_type
+    disk_size_gb    = var.disk_size_gb
     service_account = var.service_account_email
 
     dynamic "taint" {
       for_each = var.taints == null ? [] : var.taints
       content {
-        key = taint.value["key"]
-        value = taint.value["value"]
+        key    = taint.value["key"]
+        value  = taint.value["value"]
         effect = taint.value["effect"]
       }
     }

--- a/templates/terraform/k8s-node-pool/variables.tf
+++ b/templates/terraform/k8s-node-pool/variables.tf
@@ -1,13 +1,13 @@
 # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
 variable dependencies {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules"
 }
 
 variable enable_autoscaling {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Toggle to enable autoscaling of node pool."
 }
 
@@ -21,44 +21,44 @@ variable autoscaling {
 
 variable taints {
   type = list(object({
-    key = string
-    value = string
+    key    = string
+    value  = string
     effect = string
   }))
   description = "List of taints to apply to the nodes in the node pool."
 }
 
 variable name {
-  type = string
+  type        = string
   description = "Name to assign to the node pool."
 }
 
 variable master_name {
-  type = string
+  type        = string
   description = "Name of the GKE master / cluster where the node pool should be provisioned."
 }
 
 variable location {
-  type = string
+  type        = string
   description = "Location where the node pool should be provisioned."
 }
 
 variable node_count {
-  type = number
+  type        = number
   description = "Number of nodes to provision in the pool."
 }
 
 variable machine_type {
-  type = string
+  type        = string
   description = "API ID for the machine type to run in the node pool."
 }
 
 variable disk_size_gb {
-  type = number
+  type        = number
   description = "Size of disk to allocate for each node in the pool."
 }
 
 variable service_account_email {
-  type = string
+  type        = string
   description = "The email address of the IAM service account that will run system pods."
 }

--- a/templates/terraform/monster-infrastructure/clinvar.tf
+++ b/templates/terraform/monster-infrastructure/clinvar.tf
@@ -2,16 +2,16 @@ module clinvar {
   source = "../processing-project"
   providers = {
     google.target = google.clinvar,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  project_name = "broad-dsp-monster-clingen-${local.env}"
-  is_production = var.is_production
+  project_name                      = "broad-dsp-monster-clingen-${local.env}"
+  is_production                     = var.is_production
   command_center_argo_account_email = module.command_center.clinvar_argo_runner_email
-  region = "us-central1"
-  create_results_bucket = true
-  result_reader_groups = ["clingendevs@broadinstitute.org"]
-  jade_repo_email = local.jade_repo_email
-  deletion_age_days = 14
-  vault_prefix = "${local.vault_prefix}/processing-projects/clinvar"
+  region                            = "us-central1"
+  create_results_bucket             = true
+  result_reader_groups              = ["clingendevs@broadinstitute.org"]
+  jade_repo_email                   = local.jade_repo_email
+  deletion_age_days                 = 14
+  vault_prefix                      = "${local.vault_prefix}/processing-projects/clinvar"
 }

--- a/templates/terraform/monster-infrastructure/clinvar.tf
+++ b/templates/terraform/monster-infrastructure/clinvar.tf
@@ -1,5 +1,5 @@
 module clinvar {
-  source = ".//processing-project"
+  source = "..//processing-project"
   providers = {
     google.target = google.clinvar,
     vault.target = vault.target

--- a/templates/terraform/monster-infrastructure/clinvar.tf
+++ b/templates/terraform/monster-infrastructure/clinvar.tf
@@ -1,5 +1,5 @@
 module clinvar {
-  source = "..//processing-project"
+  source = "../processing-project"
   providers = {
     google.target = google.clinvar,
     vault.target = vault.target

--- a/templates/terraform/monster-infrastructure/clinvar.tf
+++ b/templates/terraform/monster-infrastructure/clinvar.tf
@@ -1,5 +1,5 @@
 module clinvar {
-  source = "/templates/processing-project"
+  source = ".//processing-project"
   providers = {
     google.target = google.clinvar,
     vault.target = vault.target

--- a/templates/terraform/monster-infrastructure/command-center.tf
+++ b/templates/terraform/monster-infrastructure/command-center.tf
@@ -1,7 +1,4 @@
 module command_center {
-  # NOTE: This path is where we expect the template to be mounted
-  # within the Docker image we run in init.sh, not where we expect
-  # it to be located in the git repo.
   source = "../command-center-project"
   providers = {
     google.target = google.command-center,

--- a/templates/terraform/monster-infrastructure/command-center.tf
+++ b/templates/terraform/monster-infrastructure/command-center.tf
@@ -2,7 +2,7 @@ module command_center {
   # NOTE: This path is where we expect the template to be mounted
   # within the Docker image we run in init.sh, not where we expect
   # it to be located in the git repo.
-  source = "..//command-center-project"
+  source = "../command-center-project"
   providers = {
     google.target = google.command-center,
     vault.target = vault.target

--- a/templates/terraform/monster-infrastructure/command-center.tf
+++ b/templates/terraform/monster-infrastructure/command-center.tf
@@ -2,7 +2,7 @@ module command_center {
   # NOTE: This path is where we expect the template to be mounted
   # within the Docker image we run in init.sh, not where we expect
   # it to be located in the git repo.
-  source = ".//command-center-project"
+  source = "..//command-center-project"
   providers = {
     google.target = google.command-center,
     vault.target = vault.target

--- a/templates/terraform/monster-infrastructure/command-center.tf
+++ b/templates/terraform/monster-infrastructure/command-center.tf
@@ -2,7 +2,7 @@ module command_center {
   # NOTE: This path is where we expect the template to be mounted
   # within the Docker image we run in init.sh, not where we expect
   # it to be located in the git repo.
-  source = "/templates/command-center-project"
+  source = ".//command-center-project"
   providers = {
     google.target = google.command-center,
     vault.target = vault.target

--- a/templates/terraform/monster-infrastructure/command-center.tf
+++ b/templates/terraform/monster-infrastructure/command-center.tf
@@ -5,10 +5,10 @@ module command_center {
   source = "../command-center-project"
   providers = {
     google.target = google.command-center,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  is_production = var.is_production
+  is_production    = var.is_production
   k8s_cluster_size = var.cluster_size
   k8s_machine_type = var.machine_type
   # 4 CPU, 15 GiB of RAM.

--- a/templates/terraform/monster-infrastructure/encode.tf
+++ b/templates/terraform/monster-infrastructure/encode.tf
@@ -1,5 +1,5 @@
 module encode {
-  source = "..//processing-project"
+  source = "../processing-project"
   providers = {
     google.target = google.encode,
     vault.target = vault.target
@@ -15,7 +15,7 @@ module encode {
 }
 
 module encode_s3_user {
-  source = "..//aws-sa"
+  source = "../aws-sa"
   providers = {
     aws.target = aws.encode
   }

--- a/templates/terraform/monster-infrastructure/encode.tf
+++ b/templates/terraform/monster-infrastructure/encode.tf
@@ -2,16 +2,16 @@ module encode {
   source = "../processing-project"
   providers = {
     google.target = google.encode,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  project_name = "broad-dsp-monster-encode-${local.env}"
-  is_production = var.is_production
+  project_name                      = "broad-dsp-monster-encode-${local.env}"
+  is_production                     = var.is_production
   command_center_argo_account_email = module.command_center.encode_argo_runner_email
-  region = "us-west1"
-  jade_repo_email = local.jade_repo_email
-  deletion_age_days = 14
-  vault_prefix = "${local.vault_prefix}/processing-projects/encode"
+  region                            = "us-west1"
+  jade_repo_email                   = local.jade_repo_email
+  deletion_age_days                 = 14
+  vault_prefix                      = "${local.vault_prefix}/processing-projects/encode"
 }
 
 module encode_s3_user {
@@ -26,7 +26,7 @@ module encode_s3_user {
   iam_policy = [
     {
       subject_id = "ObjectActions",
-      actions = ["s3:GetObject"]
+      actions    = ["s3:GetObject"]
       resources = [
         "arn:aws:s3:::encode-public/*"
       ]

--- a/templates/terraform/monster-infrastructure/encode.tf
+++ b/templates/terraform/monster-infrastructure/encode.tf
@@ -1,5 +1,5 @@
 module encode {
-  source = "/templates/processing-project"
+  source = ".//processing-project"
   providers = {
     google.target = google.encode,
     vault.target = vault.target
@@ -15,7 +15,7 @@ module encode {
 }
 
 module encode_s3_user {
-  source = "/templates/aws-sa"
+  source = ".//aws-sa"
   providers = {
     aws.target = aws.encode
   }

--- a/templates/terraform/monster-infrastructure/encode.tf
+++ b/templates/terraform/monster-infrastructure/encode.tf
@@ -1,5 +1,5 @@
 module encode {
-  source = ".//processing-project"
+  source = "..//processing-project"
   providers = {
     google.target = google.encode,
     vault.target = vault.target
@@ -15,7 +15,7 @@ module encode {
 }
 
 module encode_s3_user {
-  source = ".//aws-sa"
+  source = "..//aws-sa"
   providers = {
     aws.target = aws.encode
   }

--- a/templates/terraform/monster-infrastructure/variables.tf
+++ b/templates/terraform/monster-infrastructure/variables.tf
@@ -1,26 +1,26 @@
 variable is_production {
-  type = bool
+  type        = bool
   description = "true -> prod, false -> dev."
-  default = false
+  default     = false
 }
 
 variable cluster_size {
-  type = number
+  type        = number
   description = "Size of k8s cluster for command center."
 }
 
 variable machine_type {
-  type = string
+  type        = string
   description = "Machine type of k8s cluster for command center."
 }
 
 variable db_tier {
-  type = string
+  type        = string
   description = "Database specification for command center."
 }
 
 locals {
-  env = var.is_production ? "prod" : "dev"
+  env             = var.is_production ? "prod" : "dev"
   jade_repo_email = var.is_production ? "terra-data-repository@broad-datarepo-terra-prod.iam.gserviceaccount.com" : "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com"
-  vault_prefix = "secret/dsde/monster/${local.env}"
+  vault_prefix    = "secret/dsde/monster/${local.env}"
 }

--- a/templates/terraform/processing-project/buckets.tf
+++ b/templates/terraform/processing-project/buckets.tf
@@ -1,7 +1,7 @@
 # Bucket for temp files used by processing programs.
 resource google_storage_bucket temp_bucket {
   provider = google.target
-  name = "${var.project_name}-temp-storage"
+  name     = "${var.project_name}-temp-storage"
   location = "US"
 
   lifecycle_rule {
@@ -18,19 +18,19 @@ resource google_storage_bucket temp_bucket {
 
 resource google_storage_bucket_iam_member temp_bucket_runner_iam {
   provider = google.target
-  bucket = google_storage_bucket.temp_bucket.name
+  bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.dataflow_runner_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.dataflow_runner_account.email}"
   depends_on = [module.dataflow_runner_account.delay]
 }
 
 # Bucket for temporary data storage.
 resource google_storage_bucket staging_storage {
   provider = google.target
-  name = "${var.project_name}-staging-storage"
+  name     = "${var.project_name}-staging-storage"
   location = "US"
 
   dynamic "lifecycle_rule" {
@@ -48,74 +48,74 @@ resource google_storage_bucket staging_storage {
 
 resource google_storage_bucket_iam_member staging_bucket_runner_iam {
   provider = google.target
-  bucket = google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
-  member = "serviceAccount:${module.dataflow_runner_account.email}"
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.dataflow_runner_account.email}"
   depends_on = [module.dataflow_runner_account.delay]
 }
 
 resource google_storage_bucket_iam_member command_center_argo_staging_bucket_iam {
   provider = google.target
-  bucket =  google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${var.command_center_argo_account_email}"
 }
 
 resource google_storage_bucket_iam_member command_center_argo_temp_bucket_iam {
   provider = google.target
-  bucket =  google_storage_bucket.temp_bucket.name
+  bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${var.command_center_argo_account_email}"
 }
 
 resource google_storage_bucket_iam_member staging_account_iam_reader {
   provider = google.target
-  bucket = google_storage_bucket.staging_storage.name
+  bucket   = google_storage_bucket.staging_storage.name
   # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${var.jade_repo_email}"
 }
 
 # Bucket for long term Argo logs storage, currently want no "delete after N days" rule.
 resource google_storage_bucket argo_archive {
   provider = google.target
-  name = "${var.project_name}-argo-archive"
+  name     = "${var.project_name}-argo-archive"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member command_center_argo_logs_bucket_iam {
   provider = google.target
-  bucket =  google_storage_bucket.argo_archive.name
+  bucket   = google_storage_bucket.argo_archive.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${var.command_center_argo_account_email}"
 }
 
 resource google_storage_bucket results_storage {
   provider = google.target
-  count = var.create_results_bucket ? 1 : 0
+  count    = var.create_results_bucket ? 1 : 0
 
-  name = "${var.project_name}-ingest-results"
+  name     = "${var.project_name}-ingest-results"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member results_writer {
   provider = google.target
-  count = var.create_results_bucket ? 1 : 0
+  count    = var.create_results_bucket ? 1 : 0
 
   bucket = google_storage_bucket.results_storage[0].name
-  role = "roles/storage.admin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${var.command_center_argo_account_email}"
 }
 
@@ -124,8 +124,8 @@ resource google_storage_bucket_iam_member results_external_readers {
   for_each = toset(var.create_results_bucket ? var.result_reader_groups : [])
 
   provider = google.target
-  bucket = google_storage_bucket.results_storage[0].name
+  bucket   = google_storage_bucket.results_storage[0].name
   # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "group:${each.value}"
 }

--- a/templates/terraform/processing-project/networks.tf
+++ b/templates/terraform/processing-project/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = ".//compute-network"
+  source = "..//compute-network"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/processing-project/networks.tf
+++ b/templates/terraform/processing-project/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "..//compute-network"
+  source = "../compute-network"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/processing-project/networks.tf
+++ b/templates/terraform/processing-project/networks.tf
@@ -1,5 +1,5 @@
 module k8s_network {
-  source = "/templates/compute-network"
+  source = ".//compute-network"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/processing-project/networks.tf
+++ b/templates/terraform/processing-project/networks.tf
@@ -8,7 +8,7 @@ module k8s_network {
   name = "monster-processing-network"
   subnets = [{
     region = var.region,
-    cidr = "10.0.0.0/22"
+    cidr   = "10.0.0.0/22"
   }]
   enable_flow_logs = var.is_production
 }

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -1,5 +1,5 @@
 module dataflow_runner_account {
-  source = "/templates/google-sa"
+  source = ".//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -1,5 +1,5 @@
 module dataflow_runner_account {
-  source = ".//google-sa"
+  source = "..//google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -1,5 +1,5 @@
 module dataflow_runner_account {
-  source = "..//google-sa"
+  source = "../google-sa"
   providers = {
     google.target = google.target,
     vault.target = vault.target

--- a/templates/terraform/processing-project/service-accounts.tf
+++ b/templates/terraform/processing-project/service-accounts.tf
@@ -2,13 +2,13 @@ module dataflow_runner_account {
   source = "../google-sa"
   providers = {
     google.target = google.target,
-    vault.target = vault.target
+    vault.target  = vault.target
   }
 
-  account_id = "dataflow-runner"
+  account_id   = "dataflow-runner"
   display_name = " Service account to run Dataflow jobs"
-  vault_path = "${var.vault_prefix}/service-accounts/dataflow-runner"
-  roles = ["dataflow.worker"]
+  vault_path   = "${var.vault_prefix}/service-accounts/dataflow-runner"
+  roles        = ["dataflow.worker"]
 }
 
 # Allow the command-center account to run Dataflow jobs...
@@ -16,7 +16,7 @@ resource google_project_iam_member command_center_argo_account_iam {
   provider = google.target
   for_each = toset(["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"])
 
-  role = "roles/${each.value}"
+  role   = "roles/${each.value}"
   member = "serviceAccount:${var.command_center_argo_account_email}"
 }
 # ... and allow it to do so as the dataflow-runner service account.
@@ -24,6 +24,6 @@ resource google_service_account_iam_binding dataflow_runner_user_binding {
   provider = google.target
 
   service_account_id = module.dataflow_runner_account.id
-  role = "roles/iam.serviceAccountUser"
-  members = ["serviceAccount:${var.command_center_argo_account_email}"]
+  role               = "roles/iam.serviceAccountUser"
+  members            = ["serviceAccount:${var.command_center_argo_account_email}"]
 }

--- a/templates/terraform/processing-project/services.tf
+++ b/templates/terraform/processing-project/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "..//api-services"
+  source = "../api-services"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/processing-project/services.tf
+++ b/templates/terraform/processing-project/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = "/templates/api-services"
+  source = ".//api-services"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/processing-project/services.tf
+++ b/templates/terraform/processing-project/services.tf
@@ -1,5 +1,5 @@
 module enable_services {
-  source = ".//api-services"
+  source = "..//api-services"
   providers = {
     google.target = google.target
   }

--- a/templates/terraform/processing-project/variables.tf
+++ b/templates/terraform/processing-project/variables.tf
@@ -1,46 +1,46 @@
 variable project_name {
-  type = string
+  type        = string
   description = "Name of the processing project"
 }
 
 variable is_production {
-  type = bool
+  type        = bool
   description = "If true, production-level logging etc. will be enabled"
 }
 
 variable region {
-  type = string
+  type        = string
   description = "Region where processing should run"
 }
 
 variable create_results_bucket {
-  type = bool
+  type        = bool
   description = "If true, create a dedicated bucket for delivery of ingest outputs outside of the Data Repo."
-  default = false
+  default     = false
 }
 
 variable result_reader_groups {
-  type = list(string)
+  type        = list(string)
   description = "Email addresses of google groups that should be able to read from the results bucket."
-  default = []
+  default     = []
 }
 
 variable deletion_age_days {
-  type = number
+  type        = number
   description = "The number of days to wait before deleting files in the staging bucket."
 }
 
 variable vault_prefix {
-  type = string
+  type        = string
   description = "Path prefix for secrets written to Vault."
 }
 
 variable command_center_argo_account_email {
-  type = string
+  type        = string
   description = "Email which is tied to the command-center Argo service account."
 }
 
 variable jade_repo_email {
-  type = string
+  type        = string
   description = "Email for the service account running the Jade Repo."
 }


### PR DESCRIPTION
* Automatically runs Terraform plans for each environment each time a commit lands in a PR that changes our TF config, and adds a comment to the PR with the results of the plan
* Reorganizes our TF code to use relative paths to templates/modules instead of relying on a root directory mount in Docker
* Sets up centralized credentials in Vault for use in CI/automations that interact with Terraform
* Bumps our version lock for the Terraform Google provider to the latest version to account for some features being moved from google-beta to GA.