### PR TITLE
[DSPDC-1232] Slack notification secrets

### DIFF
--- a/environments/hca-prod/helm/orchestration-workflows/hca/values.yaml
+++ b/environments/hca-prod/helm/orchestration-workflows/hca/values.yaml
@@ -3,3 +3,8 @@ argo:
   vaultPrefix: secret/dsde/monster/prod/ingest/hca
   namespace: hca
   artifactBucket: broad-dsp-monster-hca-prod-argo-archive
+notification:
+  onlyOnFailure: false
+  vaultSecret:
+    path: secret/dsde/monster/prod/ingest/hca/slack-notifier
+    key: url

--- a/environments/hca-prod/helm/orchestration-workflows/hca/values.yaml
+++ b/environments/hca-prod/helm/orchestration-workflows/hca/values.yaml
@@ -7,4 +7,4 @@ notification:
   onlyOnFailure: false
   vaultSecret:
     path: secret/dsde/monster/prod/ingest/hca/slack-notifier
-    key: url
+    key: oauth-token

--- a/environments/hca/helm/orchestration-workflows/hca-mvp/values.yaml
+++ b/environments/hca/helm/orchestration-workflows/hca-mvp/values.yaml
@@ -3,3 +3,8 @@ argo:
   vaultPrefix: secret/dsde/monster/dev/ingest/hca
   namespace: hca-mvp
   artifactBucket: broad-dsp-monster-hca-dev-argo-archive
+notification:
+  onlyOnFailure: false
+  vaultSecret:
+    path: secret/dsde/monster/dev/ingest/hca/slack-notifier
+    key: url

--- a/environments/hca/helm/orchestration-workflows/hca-mvp/values.yaml
+++ b/environments/hca/helm/orchestration-workflows/hca-mvp/values.yaml
@@ -7,4 +7,4 @@ notification:
   onlyOnFailure: false
   vaultSecret:
     path: secret/dsde/monster/dev/ingest/hca/slack-notifier
-    key: url
+    key: oauth-token


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1232) 
We want slack notifications when `hca-ingest` failures.

To get that running, we need to grab the slack oauth token and put it in K8s so Argo can get at it.

## This PR
* This is somewhat hand-wavy: my understanding is that these values.yaml files are what's responsible for building up the secrets in k8s, if anyone can confirm/deny please pipe up.
* I've put the needed oauth token in vault already
* To roll this out, I _think_ I'll need to run `hack/apply-orchestration-workflow`, again please comment if I'm on the wrong track with that.