### PR TITLE
Add slack secrets to HCA prod and dev workflow yamls

### DIFF
--- a/templates/helm/orchestration-workflows/hca-mvp/templates/workflow.yaml
+++ b/templates/helm/orchestration-workflows/hca-mvp/templates/workflow.yaml
@@ -22,6 +22,12 @@ spec:
           - kubeSecretKey: {{ $keyName }}
             path: secret/dsde/monster/dev/ingest/hca/service-accounts/hca-argo-runner
             vaultKey: key
+      - secretName: slack-oauth-token
+        nameSpace: hca-mvp
+        vals:
+          - kubeSecretKey: oauth-token
+            path: secret/dsde/monster/dev/ingest/hca/slack-notifier
+            vaultKey: oauth-token
 ---
 
 apiVersion: helm.fluxcd.io/v1
@@ -56,7 +62,7 @@ spec:
     notification:
       onlyOnFailure: {{ .Values.notification.onlyOnFailure }}
       oauthToken:
-        secretName: slack-notifier
+        secretName: slack-oauth-token
         secretKey: oauth-token
     bigquery:
       stagingData:

--- a/templates/helm/orchestration-workflows/hca/templates/workflow.yaml
+++ b/templates/helm/orchestration-workflows/hca/templates/workflow.yaml
@@ -23,6 +23,12 @@ spec:
           - kubeSecretKey: {{ $keyName }}
             path: secret/dsde/monster/prod/ingest/hca/service-accounts/hca-argo-runner
             vaultKey: key
+      - secretName: slack-oauth-token
+        nameSpace: hca
+        vals:
+          - kubeSecretKey: oauth-token
+            path: secret/dsde/monster/prod/ingest/hca/slack-notifier
+            vaultKey: oauth-token
 ---
 
 apiVersion: helm.fluxcd.io/v1
@@ -54,6 +60,11 @@ spec:
       subnetName: hca-network
       workerAccount: hca-dataflow-runner@{{ $projectId }}.iam.gserviceaccount.com
       useFlexRS: {{ eq .Values.env "prod" }}
+    notification:
+      onlyOnFailure: {{ .Values.notification.onlyOnFailure }}
+      oauthToken:
+        secretName: slack-oauth-token
+        secretKey: oauth-token
     bigquery:
       stagingData:
         project: {{ $projectId }}


### PR DESCRIPTION
## Why

These secrets need to be in place for HCA in prod and dev (I had them set locally but failed to get them into git)

## This PR
* Updates the workflow yamls for hca-mvp and hca prod to reflect the slack oauth token secrets
