### PR TITLE
Encode slack configuration

### DIFF
--- a/environments/prod/helm/orchestration-workflows/encode/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/encode/values.yaml
@@ -1,5 +1,5 @@
 enable: true
-schedule: '0 8 * * 1'
+schedule: '0 8 * * 0'
 argo:
   env: prod
   vaultPrefix: secret/dsde/monster/prod/command-center

--- a/templates/helm/orchestration-workflows/encode/Chart.yaml
+++ b/templates/helm/orchestration-workflows/encode/Chart.yaml
@@ -4,6 +4,6 @@ description: Argo workflow for regular ingest of ENCODE data.
 version: 0.0.0
 dependencies:
   - name: argo-controller
-    version: 0.0.0
+    version: 0.0.1
     repository: file:///charts/argo-controller
     alias: argo

--- a/templates/helm/orchestration-workflows/encode/templates/encode.yaml
+++ b/templates/helm/orchestration-workflows/encode/templates/encode.yaml
@@ -34,14 +34,12 @@ spec:
           - kubeSecretKey: AWS_SECRET_ACCESS_KEY
             path: {{ $path }}
             vaultKey: secret_access_key
-      {{- if $smokeTest }}
-      - secretName: smoke-test-secrets
+      - secretName: slack-oauth-token
         nameSpace: encode
         vals:
-          - kubeSecretKey: slack-url
-            path: secret/dsde/monster/{{ .Values.env }}/slack-notifier
-            vaultKey: monster-ci-url
-      {{- end }}
+          - kubeSecretKey: oauth-token
+            path: secret/dsde/monster/{{ .Values.env }}/encode/slack-notifier
+            vaultKey: oauth-token
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -91,13 +89,10 @@ spec:
         dataset: {{ printf "datarepo_%s" .Values.repo.datasetName }}
     aws:
       credentialsSecretName: {{ $awsSecretName }}
-    smokeTest:
-      enable: {{ $smokeTest }}
-      {{- if $smokeTest }}
-      slackUrl:
-        secretName: smoke-test-secrets
-        secretKey: slack-url
-      {{- end }}
+    notification:
+      oauthToken:
+        secretName: slack-oauth-token
+        secretKey: oauth-token
     repo:
       {{- with .Values.repo }}
       url: {{ .url }}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1405)
We should fire slack alerts when encode's prod ingest fails.

## This PR
* "True's up" with a slack secret structure that we're leveraging for hca + clinvar
* Updates the argo controller chart version to pull in [these changes](https://github.com/broadinstitute/monster-helm/commit/37b67404061f2f008af13bc8f3e06dae7180976b)
* Updates the encode prod ingest to run on Sunday mornings