### PR TITLE
Ship master when deploying encode-ingest to prod

### DIFF
--- a/environments/prod/helm/orchestration-workflows/encode/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/encode/values.yaml
@@ -12,5 +12,5 @@ repo:
   dataProject: broad-datarepo-terra-prod-encd
   url: https://jade-terra.datarepo-prod.broadinstitute.org
 chart:
-  git: false
-  ref: 1.0.0-M2
+  git: true
+  ref: master

--- a/templates/helm/orchestration-workflows/encode/templates/encode.yaml
+++ b/templates/helm/orchestration-workflows/encode/templates/encode.yaml
@@ -89,6 +89,8 @@ spec:
         dataset: {{ printf "datarepo_%s" .Values.repo.datasetName }}
     aws:
       credentialsSecretName: {{ $awsSecretName }}
+    smokeTest:
+      enable: {{ $smokeTest }}
     notification:
       oauthToken:
         secretName: slack-oauth-token


### PR DESCRIPTION
## Why

We deploy specific tags to prod for `encode-ingest`. This means we have not shipped encode since v1.0.0-M2 was cut in June 2020. Additionally, our use of the `broadinstitute/setup-chart-releaser` is broken due to breaking changes GH made
with using `add-path`, which will be tough to fix since that GH action comes from an [archived repo](https://github.com/broadinstitute/setup-chart-releaser). 

I propose we ship `master` to prod for encode going forward.

## This PR
* Points at the `master` github ref, rather than relying on a tag.
* Adds back the `smokeTest` hash in the encode orchestration YAML, as this is needed to successfully render the slack template. 
