### PR TITLE
update profileId to the new default value everywhere applicable

### DIFF
--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -13,7 +13,7 @@ repo:
   dataProject: broad-jade-dev-data
   datasetName: monster_clinvar
   datasetId: 9952ebf2-65d9-44b7-b5a8-b500bc458909
-  profileId: b94944a9-df3d-4b35-b573-c7d9b249ea52
+  profileId: 390e7a85-d47f-4531-b612-165fc977d3bd
 notification:
   onlyOnFailure: false
   vaultSecret:

--- a/templates/helm/orchestration-workflows/hca-mvp/templates/workflow.yaml
+++ b/templates/helm/orchestration-workflows/hca-mvp/templates/workflow.yaml
@@ -79,7 +79,7 @@ spec:
       # TODO: Switch on environment
       url: https://jade.datarepo-dev.broadinstitute.org
       datasetId: 958c271f-097b-4523-ad59-5070a757a8d2
-      profileId: b94944a9-df3d-4b35-b573-c7d9b249ea52
+      profileId: 390e7a85-d47f-4531-b612-165fc977d3bd
       accessKey:
         secretName: {{ $secretName }}
         secretKey: {{ $keyName }}


### PR DESCRIPTION
## Why
Jade updated their dev deployment so now everything works off of a single profile ID. If I understand the changes correctly, all we need to do is use that default profile ID now.

## This PR
Updates the old profileId to the new default profileId.