### PR TITLE
Upgrade to the latest argo controller chart

### DIFF
--- a/templates/helm/orchestration-workflows/clinvar/Chart.yaml
+++ b/templates/helm/orchestration-workflows/clinvar/Chart.yaml
@@ -4,6 +4,6 @@ description: Argo workflow for regular ingest of ClinVar archives.
 version: 0.0.0
 dependencies:
   - name: argo-controller
-    version: 0.0.0
+    version: 0.0.1
     repository: file:///charts/argo-controller
     alias: argo


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1344)
We need to upgrade for Clinvar to the argo-controller 0.0.1 as 0.0.0 is no longer present in the repo.

## This PR
* Points the clinvar helm chart at version 0.0.1 of the argo-controller template.
