### PR TITLE
Deploy clinvar from master

### DIFF
--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -6,8 +6,8 @@ argo:
   namespace: clinvar
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
-  git: false
-  ref: 1.2.5
+  git: true
+  ref: master
 repo:
   url: https://jade-terra.datarepo-prod.broadinstitute.org
   dataProject: broad-datarepo-terra-prod-cgen


### PR DESCRIPTION
We are blocked on deploying clinvar because of an incompatibility with the `setup-chart-releaser` action and a deprecated GitHub action operation. Rather than rely on tags, we should just deploy clinvar from master.
