### PR TITLE
[DSPDC-1465] Enable the pubsub API in hca-prod

### DIFF
--- a/environments/hca-prod/terraform/services.tf
+++ b/environments/hca-prod/terraform/services.tf
@@ -22,6 +22,7 @@ module enable_services {
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",
     "dataflow.googleapis.com",
-    "storagetransfer.googleapis.com"
+    "storagetransfer.googleapis.com",
+    "pubsub.googleapis.com"
   ]
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1465)
Prior to setting up topics and subscriptions, we need to enable the pubsub API (the terraform plan will fail if this is not setup first)

## This PR
* Turns on the API for `hca-prod`
