### PR TITLE
Fix subscription name

### DIFF
--- a/environments/hca-prod/terraform/pubsub.tf
+++ b/environments/hca-prod/terraform/pubsub.tf
@@ -12,7 +12,7 @@ module ebi_staging_notification_pubsub_topic {
 # EBI can consume from the EBI transfer notifications pull subscription
 resource google_pubsub_subscription_iam_member ebi_writer_iam {
   provider     = google-beta.target
-  subscription = "staging-transfer-notifications.ebi.ebi-writer"
+  subscription = "ebi-writer"
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${module.ebi_writer_account.email}"
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1465)
The sub name in the pubsub config for HCA prod was incorrect.

## This PR
* Fixes the sub name to reflect reality