### PR TITLE
Bump argo controller chart version

### DIFF
--- a/templates/helm/argo-controller/templates/argo.yaml
+++ b/templates/helm/argo-controller/templates/argo.yaml
@@ -34,7 +34,7 @@ spec:
   chart:
     repository: https://broadinstitute.github.io/monster-helm
     name: argo-controller
-    version: 0.7.5
+    version: 0.7.6
   values:
     logs:
       bucket: {{ .Values.artifactBucket }}

--- a/templates/helm/command-center/templates/argo.yaml
+++ b/templates/helm/command-center/templates/argo.yaml
@@ -33,7 +33,7 @@ spec:
   chart:
     repository: https://broadinstitute.github.io/monster-helm
     name: argo-server
-    version: 0.7.1
+    version: 0.7.3
   values:
     clusterName: command-center-cluster
     stackdriverProject: {{ .Values.stackdriverProject }}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1564)
We need more memory to increase the # of in-flight ingests we can support for HCA.

## This PR
* Pulls in an updated chart that bumps the memory allocation for the argo controller
