### PR TITLE
[DSPDC-1590] Configure a DNS name and global static IP for argocd in hca-dev

### DIFF
--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -12,5 +12,5 @@ module dns_names {
   dependencies  = [module.enable_services]
   zone_gcp_name = data.google_dns_managed_zone.dev_zone.name
   zone_dns_name = data.google_dns_managed_zone.dev_zone.dns_name
-  dns_names     = ["hca-argo", "hca-grafana"]
+  dns_names     = ["hca-argo", "hca-grafana", "hca-argocd"]
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1590)
We need a global static IP and DNS name for argo CD in HCA dev.

## This PR
* Adds an `hca-argocd` DNS name to the terraform `dns_names` module