### PR TITLE
Add a Dagster runner SA and bind it to our Dagster K8s workloads

### DIFF
--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -128,6 +128,19 @@ module hca_argo_runner_account {
   roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
 }
 
+module hca_dagster_runner_account {
+  source = "../../../templates/terraform/google-sa"
+  providers = {
+    google.target = google-beta.target,
+    vault.target  = vault.target
+  }
+
+  account_id   = "hca-dagster-runner"
+  display_name = "Service account to run HCA's Dagster pipelines."
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dagster-runner"
+  roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
+}
+
 data google_project current_project {
   provider = google-beta.target
 }
@@ -138,6 +151,14 @@ resource google_service_account_iam_binding hca_workload_identity_binding {
   service_account_id = module.hca_argo_runner_account.id
   role               = "roles/iam.workloadIdentityUser"
   members            = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[hca-mvp/argo-runner]"]
+}
+
+resource google_service_account_iam_binding hca_dagster_workload_identity_binding {
+  provider = google-beta.target
+
+  service_account_id = module.hca_dagster_runner_account.id
+  role               = "roles/iam.workloadIdentityUser"
+  members            = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[dagster/monster-dagster]"]
 }
 
 resource google_service_account_iam_binding dataflow_runner_user_binding {


### PR DESCRIPTION
## Why

* We need a way to authenticate as a Google SA in Dagster (and a way, eventually, to interact with GCP services like Dataflow). This lets our Kubernetes workloads authenticate via a Google SA.

## This PR