### PR TITLE
[DSPDC-1627] Bump clinvar release to force a resubmit of a failed job

### DIFF
--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.2.9
+  ref: 1.3.0
 repo:
   url: https://jade-terra.datarepo-prod.broadinstitute.org
   dataProject: broad-datarepo-terra-prod-cgen


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1627)
ClinVar can't accomodate a resubmit of a job due to the bug described in this [DSPDC-1626](https://broadinstitute.atlassian.net/browse/DSPDC-1626)

## This PR
* This PR bumps the version to a new tag to force a full reingest of the failed release.
