### PR TITLE
Configure IAM role for Dagster to interact with Google services, Argo

### DIFF
--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -224,19 +224,6 @@ module hca_argo_runner_account {
   roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
 }
 
-module hca_dagster_runner_account {
-  source = "../../../templates/terraform/google-sa"
-  providers = {
-    google.target = google-beta.target,
-    vault.target  = vault.target
-  }
-
-  account_id   = "hca-dagster-runner"
-  display_name = "Service account to run HCA's Dagster pipelines."
-  vault_path   = "${local.prod_vault_prefix}/service-accounts/hca-dagster-runner"
-  roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
-}
-
 data google_project current_project {
   provider = google-beta.target
 }

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -25,9 +25,13 @@ module hca_dagster_runner_account {
     "dataflow.developer",
     "compute.viewer",
     "bigquery.jobUser",
-    "bigquery.dataOwner",
-    google_project_iam_custom_role.argo_access.id,
+    "bigquery.dataOwner"
   ]
+}
+
+resource "google_project_iam_member" "argo_access_member" {
+  role   = google_project_iam_custom_role.argo_access.id
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
 resource "google_service_account_iam_binding" "kubernetes_role_binding" {

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -21,7 +21,7 @@ module hca_dagster_runner_account {
   account_id   = "hca-dagster-runner"
   display_name = "Service account to run HCA's Dagster pipelines."
   vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dagster-runner"
-  roles        = [
+  roles = [
     "dataflow.developer",
     "compute.viewer",
     "bigquery.jobUser",
@@ -32,7 +32,7 @@ module hca_dagster_runner_account {
 
 resource "google_service_account_iam_binding" "kubernetes_role_binding" {
   service_account_id = hca_dagster_runner_account.name
-  role = "roles/iam.workloadIdentityUser"
+  role               = "roles/iam.workloadIdentityUser"
 
   members = [
     "serviceAccount:${local.prod_project_id}.svc.id.goog[dagster/monster-dagster]"

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -20,7 +20,7 @@ module hca_dagster_runner_account {
 
   account_id   = "hca-dagster-runner"
   display_name = "Service account to run HCA's Dagster pipelines."
-  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dagster-runner"
+  vault_path   = "${local.prod_vault_prefix}/service-accounts/hca-dagster-runner"
   roles = [
     "dataflow.developer",
     "compute.viewer",

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -1,0 +1,40 @@
+resource "google_project_iam_custom_role" "argo_access" {
+  role_id     = "argoworkflows.user"
+  title       = "Argo Workflows API User"
+  description = "Ability to interact with the REST API exposed by a Kubernetes cluster running Argo Workflows UI."
+  permissions = [
+    "container.thirdPartyObjects.create",
+    "container.thirdPartyObjects.delete",
+    "container.thirdPartyObjects.get",
+    "container.thirdPartyObjects.list",
+    "container.thirdPartyObjects.update",
+  ]
+}
+
+module hca_dagster_runner_account {
+  source = "../../../templates/terraform/google-sa"
+  providers = {
+    google.target = google-beta.target,
+    vault.target  = vault.target
+  }
+
+  account_id   = "hca-dagster-runner"
+  display_name = "Service account to run HCA's Dagster pipelines."
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dagster-runner"
+  roles        = [
+    "dataflow.developer",
+    "compute.viewer",
+    "bigquery.jobUser",
+    "bigquery.dataOwner",
+    google_project_iam_custom_role.argo_access.id,
+  ]
+}
+
+resource "google_service_account_iam_binding" "kubernetes_role_binding" {
+  service_account_id = hca_dagster_runner_account.name
+  role = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${local.prod_project_id}.svc.id.goog[dagster/monster-dagster]"
+  ]
+}

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -31,7 +31,7 @@ module hca_dagster_runner_account {
 }
 
 resource "google_service_account_iam_binding" "kubernetes_role_binding" {
-  service_account_id = hca_dagster_runner_account.name
+  service_account_id = module.hca_dagster_runner_account.name
   role               = "roles/iam.workloadIdentityUser"
 
   members = [

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -128,19 +128,6 @@ module hca_argo_runner_account {
   roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
 }
 
-module hca_dagster_runner_account {
-  source = "../../../templates/terraform/google-sa"
-  providers = {
-    google.target = google-beta.target,
-    vault.target  = vault.target
-  }
-
-  account_id   = "hca-dagster-runner"
-  display_name = "Service account to run HCA's Dagster pipelines."
-  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dagster-runner"
-  roles        = ["dataflow.developer", "compute.viewer", "bigquery.jobUser", "bigquery.dataOwner"]
-}
-
 data google_project current_project {
   provider = google-beta.target
 }

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -26,8 +26,12 @@ module hca_dagster_runner_account {
     "compute.viewer",
     "bigquery.jobUser",
     "bigquery.dataOwner",
-    google_project_iam_custom_role.argo_access.id,
   ]
+}
+
+resource "google_project_iam_member" "argo_access_member" {
+  role   = google_project_iam_custom_role.argo_access.id
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
 resource "google_service_account_iam_binding" "kubernetes_role_binding" {

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -1,3 +1,16 @@
+resource "google_project_iam_custom_role" "argo_access" {
+  role_id     = "argoworkflows.user"
+  title       = "Argo Workflows API User"
+  description = "Ability to interact with the REST API exposed by a Kubernetes cluster running Argo Workflows UI."
+  permissions = [
+    "container.thirdPartyObjects.create",
+    "container.thirdPartyObjects.delete",
+    "container.thirdPartyObjects.get",
+    "container.thirdPartyObjects.list",
+    "container.thirdPartyObjects.update",
+  ]
+}
+
 module hca_dagster_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
@@ -14,19 +27,6 @@ module hca_dagster_runner_account {
     "bigquery.jobUser",
     "bigquery.dataOwner",
     google_project_iam_custom_role.argo_access.id,
-  ]
-}
-
-resource "google_project_iam_custom_role" "argo_access" {
-  role_id     = "argoworkflows.user"
-  title       = "Argo Workflows API User"
-  description = "Ability to interact with the REST API exposed by a Kubernetes cluster running Argo Workflows UI."
-  permissions = [
-    "container.thirdPartyObjects.create",
-    "container.thirdPartyObjects.delete",
-    "container.thirdPartyObjects.get",
-    "container.thirdPartyObjects.list",
-    "container.thirdPartyObjects.update",
   ]
 }
 

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -31,7 +31,7 @@ module hca_dagster_runner_account {
 }
 
 resource "google_service_account_iam_binding" "kubernetes_role_binding" {
-  service_account_id = hca_dagster_runner_account.name
+  service_account_id = module.hca_dagster_runner_account.name
   role               = "roles/iam.workloadIdentityUser"
 
   members = [

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -21,7 +21,7 @@ module hca_dagster_runner_account {
   account_id   = "hca-dagster-runner"
   display_name = "Service account to run HCA's Dagster pipelines."
   vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dagster-runner"
-  roles        = [
+  roles = [
     "dataflow.developer",
     "compute.viewer",
     "bigquery.jobUser",
@@ -32,7 +32,7 @@ module hca_dagster_runner_account {
 
 resource "google_service_account_iam_binding" "kubernetes_role_binding" {
   service_account_id = hca_dagster_runner_account.name
-  role = "roles/iam.workloadIdentityUser"
+  role               = "roles/iam.workloadIdentityUser"
 
   members = [
     "serviceAccount:${local.dev_project_name}.svc.id.goog[dagster/monster-dagster]"

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -1,0 +1,40 @@
+module hca_dagster_runner_account {
+  source = "../../../templates/terraform/google-sa"
+  providers = {
+    google.target = google-beta.target,
+    vault.target  = vault.target
+  }
+
+  account_id   = "hca-dagster-runner"
+  display_name = "Service account to run HCA's Dagster pipelines."
+  vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-dagster-runner"
+  roles        = [
+    "dataflow.developer",
+    "compute.viewer",
+    "bigquery.jobUser",
+    "bigquery.dataOwner",
+    google_project_iam_custom_role.argo_access.id,
+  ]
+}
+
+resource "google_project_iam_custom_role" "argo_access" {
+  role_id     = "argoworkflows.user"
+  title       = "Argo Workflows API User"
+  description = "Ability to interact with the REST API exposed by a Kubernetes cluster running Argo Workflows UI."
+  permissions = [
+    "container.thirdPartyObjects.create",
+    "container.thirdPartyObjects.delete",
+    "container.thirdPartyObjects.get",
+    "container.thirdPartyObjects.list",
+    "container.thirdPartyObjects.update",
+  ]
+}
+
+resource "google_service_account_iam_binding" "kubernetes_role_binding" {
+  service_account_id = hca_dagster_runner_account.name
+  role = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${local.dev_project_name}.svc.id.goog[dagster/monster-dagster]"
+  ]
+}

--- a/templates/terraform/google-sa/outputs.tf
+++ b/templates/terraform/google-sa/outputs.tf
@@ -2,6 +2,10 @@ output email {
   value = google_service_account.sa.email
 }
 
+output name {
+  value = google_service_account.sa.name
+}
+
 output delay {
   value = null_resource.sa_delay
 }


### PR DESCRIPTION
## Why

This configures the Dagster service account to be able to interact with the services we need, and sets up the Google side of binding it to the Kubernetes cluster running Dagster (so pods can interact with Google services as this SA). It also adds the requisite permissions for the SA to authenticate with Argo Workflows' REST API.
## This PR