### PR TITLE
Grant Dagster runner SA access to our staging buckets

### DIFF
--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -247,14 +247,6 @@ resource google_service_account_iam_binding hca_workload_identity_binding {
   members            = ["serviceAccount:${local.prod_project_id}.svc.id.goog[hca/argo-runner]"]
 }
 
-resource google_service_account_iam_binding hca_dagster_workload_identity_binding {
-  provider = google-beta.target
-
-  service_account_id = module.hca_dagster_runner_account.id
-  role               = "roles/iam.workloadIdentityUser"
-  members            = ["serviceAccount:${local.prod_project_id}.svc.id.goog[dagster/monster-dagster]"]
-}
-
 resource google_service_account_iam_binding dataflow_runner_user_binding {
   provider = google-beta.target
 

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -1,4 +1,4 @@
-resource "google_project_iam_custom_role" "argo_access" {
+resource google_project_iam_custom_role argo_access {
   provider = google-beta.target
 
   role_id     = "argoworkflows.user"
@@ -31,14 +31,14 @@ module hca_dagster_runner_account {
   ]
 }
 
-resource "google_project_iam_member" "argo_access_member" {
+resource google_project_iam_member argo_access_member {
   provider = google-beta.target
 
   role   = google_project_iam_custom_role.argo_access.id
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
-resource "google_service_account_iam_binding" "kubernetes_role_binding" {
+resource google_service_account_iam_binding kubernetes_role_binding {
   provider = google-beta.target
 
   service_account_id = module.hca_dagster_runner_account.name
@@ -47,4 +47,14 @@ resource "google_service_account_iam_binding" "kubernetes_role_binding" {
   members = [
     "serviceAccount:${local.prod_project_id}.svc.id.goog[dagster/monster-dagster]"
   ]
+}
+
+resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
+  provider = google-beta.target
+  bucket   = google_storage_bucket.staging_storage.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -41,7 +41,7 @@ resource google_project_iam_member argo_access_member {
 resource google_service_account_iam_binding kubernetes_role_binding {
   provider = google-beta.target
 
-  service_account_id = module.hca_dagster_runner_account.name
+  service_account_id = module.hca_dagster_runner_account.id
   role               = "roles/iam.workloadIdentityUser"
 
   members = [

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -140,14 +140,6 @@ resource google_service_account_iam_binding hca_workload_identity_binding {
   members            = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[hca-mvp/argo-runner]"]
 }
 
-resource google_service_account_iam_binding hca_dagster_workload_identity_binding {
-  provider = google-beta.target
-
-  service_account_id = module.hca_dagster_runner_account.id
-  role               = "roles/iam.workloadIdentityUser"
-  members            = ["serviceAccount:${data.google_project.current_project.name}.svc.id.goog[dagster/monster-dagster]"]
-}
-
 resource google_service_account_iam_binding dataflow_runner_user_binding {
   provider = google-beta.target
 

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -1,4 +1,4 @@
-resource "google_project_iam_custom_role" "argo_access" {
+resource google_project_iam_custom_role argo_access {
   provider = google-beta.target
 
   role_id     = "argoworkflows.user"
@@ -31,14 +31,14 @@ module hca_dagster_runner_account {
   ]
 }
 
-resource "google_project_iam_member" "argo_access_member" {
+resource google_project_iam_member argo_access_member {
   provider = google-beta.target
 
   role   = google_project_iam_custom_role.argo_access.id
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
-resource "google_service_account_iam_binding" "kubernetes_role_binding" {
+resource google_service_account_iam_binding kubernetes_role_binding {
   provider = google-beta.target
 
   service_account_id = module.hca_dagster_runner_account.name
@@ -47,4 +47,14 @@ resource "google_service_account_iam_binding" "kubernetes_role_binding" {
   members = [
     "serviceAccount:${local.dev_project_name}.svc.id.goog[dagster/monster-dagster]"
   ]
+}
+
+resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
+  provider = google-beta.target
+  bucket   = google_storage_bucket.staging_storage.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -41,7 +41,7 @@ resource google_project_iam_member argo_access_member {
 resource google_service_account_iam_binding kubernetes_role_binding {
   provider = google-beta.target
 
-  service_account_id = module.hca_dagster_runner_account.name
+  service_account_id = module.hca_dagster_runner_account.id
   role               = "roles/iam.workloadIdentityUser"
 
   members = [


### PR DESCRIPTION
## Why

Currently, the Dagster runner can't access the staging buckets we use for HCA imports, which prevents it from running the stage-data pipeline.

This also removes some duplicate IAM binding resources and standardizes some formatting.

## This PR