### PR TITLE
Give Dagster SA access to temp bucket

### DIFF
--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -58,3 +58,13 @@ resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
   role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
+
+resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
+  provider = google-beta.target
+  bucket   = google_storage_bucket.temp_bucket.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
+}

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -68,3 +68,11 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
+
+resource google_service_account_iam_binding dataflow_runner_dagster_user_binding {
+  provider = google-beta.target
+
+  service_account_id = module.hca_dataflow_account.id
+  role               = "roles/iam.serviceAccountUser"
+  members            = ["serviceAccount:${module.hca_dagster_runner_account.email}"]
+}

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -58,3 +58,13 @@ resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
   role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
+
+resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
+  provider = google-beta.target
+  bucket   = google_storage_bucket.temp_bucket.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
+}

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -68,3 +68,12 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
+
+resource google_service_account_iam_binding dataflow_runner_dagster_user_binding {
+  provider = google-beta.target
+
+  service_account_id = module.hca_dataflow_account.id
+  role               = "roles/iam.serviceAccountUser"
+  members            = ["serviceAccount:${module.hca_dagster_runner_account.email}"]
+}
+

--- a/hack/apply-terraform
+++ b/hack/apply-terraform
@@ -8,10 +8,14 @@ source ${SCRIPT_DIR}/common.sh
 
 declare -r TF_TEMPLATES_PATH=${REPO_ROOT}/templates/terraform
 
+action=${2:-apply}
+
+argct="$#"
+
 function main () {
   # Check args.
-  if [ $# -ne 1 ]; then
-    1>&2 echo Usage: ${0} '<env>'
+  if (( argct > 2 )) || (( argct == 0 )); then
+    1>&2 echo Usage: ${0} '<env> [<command> (default: apply)]'
     exit 1
   fi
 
@@ -49,9 +53,11 @@ function main () {
   rm -rf ${env_dir}/terraform/.terraform/modules
 
   ${terraform[@]} init
-  ${terraform[@]} apply
+  ${terraform[@]} "$action"
 
-  fire_slack_deployment_notification "terraform" "$1"
+  if [[ "$action" == "apply" ]]; then
+    fire_slack_deployment_notification "terraform" "$1"
+  fi
 }
 
 main ${@}


### PR DESCRIPTION
## Why

Temp bucket access is required to run Dataflow jobs that access the temp bucket using Dagster.

## This PR