### PR TITLE
ra dspdc 1656 clinvar dev auto snapshot

### DIFF
--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -6,8 +6,8 @@ argo:
   namespace: clinvar
   artifactBucket: broad-dsp-monster-clingen-dev-argo-archive
 chart:
-  git: true
-  ref: master
+  git: false
+  ref: 1.3.2
 repo:
   url: https://jade.datarepo-dev.broadinstitute.org
   dataProject: broad-jade-dev-data


### PR DESCRIPTION
## Why
We are unable to test certain things in dev due to certain parts of the clinvar workflow only running when the version is pinned (as opposed to using "latest").
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1656)

## This PR
Changes chart values to versioned ref instead of git master branch for clinvar dev, aka pins the version for dev