### PR TITLE
[DSPDC-1698] Give HCA dev test runner SA appropriate BQ permissions

### DIFF
--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -27,5 +27,5 @@ module hca_test_account {
   account_id   = "hca-test-runner"
   display_name = "Service account to run HCA tests"
   vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-test-runner"
-  roles        = ["dataflow.worker", "dataflow.admin",  "bigquery.jobUser", "bigquery.dataOwner"]
+  roles        = ["dataflow.worker", "dataflow.admin", "bigquery.jobUser", "bigquery.dataOwner"]
 }

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -27,5 +27,5 @@ module hca_test_account {
   account_id   = "hca-test-runner"
   display_name = "Service account to run HCA tests"
   vault_path   = "${local.dev_vault_prefix}/service-accounts/hca-test-runner"
-  roles        = ["dataflow.worker", "dataflow.admin"]
+  roles        = ["dataflow.worker", "dataflow.admin",  "bigquery.jobUser", "bigquery.dataOwner"]
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1698)
Our E2E dagster pipeline tests need to create a "staging" dataset in our HCA dev BQ project

## This PR
* Grants the `hca-test-runner` SA the required BQ permissions to create a dataset
