### PR TITLE
Fire Slack notifications to monster-deploy on merges to master

### DIFF
--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -95,10 +95,10 @@ jobs:
           method: approle
           roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
           secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slack_token
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
           exportEnv: false
     outputs:
-      slack_token: ${{ steps.vault-lookup.outputs.slack_token }}
+      slack_token: ${{ steps.vault-lookup.outputs.slackToken }}
   notify_deploy_start:
     name: Announce deployments starting
     needs: get_slack_token

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -1,12 +1,13 @@
 name: 'Apply Master Changes'
 env:
   terraform_version: "0.12.24"
-  # this value should match the envs listed in the matrix of the terraform_apply job
+  # this value should match the envs listed in the matrix of the terraform_apply job. used to
+  # list environments affected by a deploy in our slack notifications
   envs_being_deployed: "dev, hca, hca-prod, prod, v2f-prod"
-on: [push]
-  # push:
-  #   branches:
-  #     - master
+on:
+  push:
+    branches:
+      - master
 jobs:
   terraform_apply:
     timeout-minutes: 30

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -83,8 +83,8 @@ jobs:
   #       run: "TF_LOG=info terraform apply -auto-approve -input=false ${{ env.terraform_directory }}"
   #       env:
   #         VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-  get_slack_token:
-    name: Get Slack token
+  notify_deploy_start:
+    name: Announce deployments starting
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Slack token
@@ -97,13 +97,6 @@ jobs:
           secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
           secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
           exportEnv: false
-    outputs:
-      slack_token: ${{ steps.vault-lookup.outputs.slackToken }}
-  notify_deploy_start:
-    name: Announce deployments starting
-    needs: get_slack_token
-    runs-on: ubuntu-latest
-    steps:
       - name: Send Slack notification
         id: notification
         uses: voxmedia/github-action-slack-notify-build@v1
@@ -114,7 +107,7 @@ jobs:
             (dev, hca, hca-prod, prod, v2f-prod)
           color: warning
         env:
-          SLACK_BOT_TOKEN: ${{ needs.get_slack_token.outputs.slack_token }}
+          SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slack_token }}
     outputs:
       message_id: ${{ steps.notification.outputs.message_id }}
   oh_no_i_broke:
@@ -128,10 +121,19 @@ jobs:
     name: Announce deployments finishing
     runs-on: ubuntu-latest
     needs:
-      - get_slack_token
       - notify_deploy_start
       - oh_no_i_broke
     steps:
+      - name: Fetch Slack token
+        id: vault-lookup
+        uses: hashicorp/vault-action@v2.1.2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+          secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          exportEnv: false
       - name: Send Slack notification
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
@@ -142,16 +144,25 @@ jobs:
           color: success
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:
-          SLACK_BOT_TOKEN: ${{ needs.get_slack_token.outputs.slack_token }}
+          SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slack_token }}
   notify_deploy_failure:
     name: Announce deployments failed
     runs-on: ubuntu-latest
-    if: "failure()&&(needs.get_slack_token.result=='success')&&(needs.notify_deploy_start.result=='success')"
+    if: "failure()&&(needs.notify_deploy_start.result=='success')"
     needs:
-      - get_slack_token
       - notify_deploy_start
       - oh_no_i_broke
     steps:
+      - name: Fetch Slack token
+        id: vault-lookup
+        uses: hashicorp/vault-action@v2.1.2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+          secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          exportEnv: false
       - name: Send Slack notification
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
@@ -162,4 +173,4 @@ jobs:
           color: error
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:
-          SLACK_BOT_TOKEN: ${{ needs.get_slack_token.outputs.slack_token }}
+          SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slack_token }}

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -101,7 +101,7 @@ jobs:
         id: notification
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: monster-deploy
+          channel_id: C01QNFFKAG2  # monster-deploy
           status: TESTING NOTIFICATION Deploying to dev, hca, hca-prod, prod, v2f-prod
           color: warning
         env:

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -1,88 +1,91 @@
 name: 'Apply Master Changes'
 env:
   terraform_version: "0.12.24"
+  # this value should match the envs listed in the matrix of the terraform_apply job
+  envs_being_deployed: "dev, hca, hca-prod, prod, v2f-prod"
 on: [push]
   # push:
   #   branches:
   #     - master
 jobs:
-  # terraform_apply:
-  #   timeout-minutes: 30
-  #   strategy:
-  #     matrix:
-  #       include:
-  #       - environment: dev
-  #         vault_env: dev
-  #         vault_role_id_secret: MONSTER_AUTH_ROLE_ID
-  #         vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-  #       - environment: hca
-  #         vault_env: dev
-  #         vault_role_id_secret: MONSTER_AUTH_ROLE_ID
-  #         vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-  #       - environment: hca-prod
-  #         vault_env: prod
-  #         vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
-  #         vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-  #       - environment: prod
-  #         vault_env: prod
-  #         vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
-  #         vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-  #       - environment: v2f-prod
-  #         vault_env: prod
-  #         vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
-  #         vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-  #   name: "${{ matrix.environment }} Terraform Apply"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
-  #     VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-  #     GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
-  #     AWS_REGION: us-east-1
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+  terraform_apply:
+    timeout-minutes: 30
+    needs: notify_deploy_start
+    strategy:
+      matrix:
+        include:
+        - environment: dev
+          vault_env: dev
+          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+        - environment: hca
+          vault_env: dev
+          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+        - environment: hca-prod
+          vault_env: prod
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+        - environment: prod
+          vault_env: prod
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+        - environment: v2f-prod
+          vault_env: prod
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+    name: "${{ matrix.environment }} Terraform Apply"
+    runs-on: ubuntu-latest
+    env:
+      terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: install terraform
-  #       uses: hashicorp/setup-terraform@v1.2.1
-  #       with:
-  #         terraform_version: ${{ env.terraform_version }}
+      - name: install terraform
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_version: ${{ env.terraform_version }}
 
-  #     - name: "${{ matrix.environment }} set VAULT_TOKEN"
-  #       id: token
-  #       run: |
-  #         VAULT_TOKEN=$(curl \
-  #           --request POST \
-  #           --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
-  #           ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
-  #         echo ::add-mask::${VAULT_TOKEN}
-  #         echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
-  #         echo ::set-output name=vault_token::${VAULT_TOKEN}
-  #       env:
-  #         ROLE_ID: ${{ secrets[matrix.vault_role_id_secret] }}
-  #         SECRET_ID: ${{ secrets[matrix.vault_secret_id_secret] }}
+      - name: "${{ matrix.environment }} set VAULT_TOKEN"
+        id: token
+        run: |
+          VAULT_TOKEN=$(curl \
+            --request POST \
+            --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
+            ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
+          echo ::add-mask::${VAULT_TOKEN}
+          echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
+          echo ::set-output name=vault_token::${VAULT_TOKEN}
+        env:
+          ROLE_ID: ${{ secrets[matrix.vault_role_id_secret] }}
+          SECRET_ID: ${{ secrets[matrix.vault_secret_id_secret] }}
 
 
-  #     - name: "${{ matrix.environment }} consul-template render templates for terraform"
-  #       uses: broadinstitute/github-action-consul-template@master
-  #       with:
-  #         vault-address: ${{ secrets.VAULT_ADDR }}
-  #         vault-token: ${{ steps.token.outputs.vault_token }}
-  #         environment: ${{ matrix.vault_env }}
-  #         env_path: "environments"
+      - name: "${{ matrix.environment }} consul-template render templates for terraform"
+        uses: broadinstitute/github-action-consul-template@master
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-token: ${{ steps.token.outputs.vault_token }}
+          environment: ${{ matrix.vault_env }}
+          env_path: "environments"
 
-  #     - name: "${{ matrix.environment }} - Terraform Init"
-  #       id: init
-  #       run: terraform init ${{ env.terraform_directory }}
-  #       env:
-  #         VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+      - name: "${{ matrix.environment }} - Terraform Init"
+        id: init
+        run: terraform init ${{ env.terraform_directory }}
+        env:
+          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
 
-  #     - name: "${{ matrix.environment }} - Terraform Apply"
-  #       id: apply
-  #       run: "TF_LOG=info terraform apply -auto-approve -input=false ${{ env.terraform_directory }}"
-  #       env:
-  #         VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+      - name: "${{ matrix.environment }} - Terraform Apply"
+        id: apply
+        run: "TF_LOG=info terraform apply -auto-approve -input=false ${{ env.terraform_directory }}"
+        env:
+          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
   notify_deploy_start:
     name: Announce deployments starting
     runs-on: ubuntu-latest
@@ -105,25 +108,18 @@ jobs:
           status: |
             DEPLOYMENT IN PROGRESS
             DEPLOY FOR ENVS:
-            (dev, hca, hca-prod, prod, v2f-prod)
+            ${{ env.envs_being_deployed }}
           color: warning
         env:
           SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slack_token }}
     outputs:
       message_id: ${{ steps.notification.outputs.message_id }}
-  oh_no_i_broke:
-    name: Test job that always fails
-    runs-on: ubuntu-latest
-    needs: notify_deploy_start
-    steps:
-      - name: do thing
-        run: aaaaaaaaa
   notify_deploy_finish:
     name: Announce deployments finishing
     runs-on: ubuntu-latest
     needs:
       - notify_deploy_start
-      - oh_no_i_broke
+      - terraform_apply
     steps:
       - name: Fetch Slack token
         id: vault-lookup
@@ -142,7 +138,7 @@ jobs:
           status: |
             DEPLOYMENT SUCCESSFUL
             DEPLOY FOR ENVS:
-            dev, hca, hca-prod, prod, v2f-prod
+            ${{ env.envs_being_deployed }}
           color: good
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:
@@ -153,7 +149,7 @@ jobs:
     if: "failure()&&(needs.notify_deploy_start.result=='success')"
     needs:
       - notify_deploy_start
-      - oh_no_i_broke
+      - terraform_apply
     steps:
       - name: Fetch Slack token
         id: vault-lookup
@@ -173,7 +169,7 @@ jobs:
             DEPLOYMENT FAILED
             Click Workflow to list failed environments.
             DEPLOY FOR ENVS:
-            dev, hca, hca-prod, prod, v2f-prod
+            ${{ env.envs_being_deployed }}
           color: danger
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -95,7 +95,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
           secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slack_token
           exportEnv: false
       - name: Send Slack notification
         id: notification
@@ -132,7 +132,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
           secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slack_token
           exportEnv: false
       - name: Send Slack notification
         uses: voxmedia/github-action-slack-notify-build@v1
@@ -161,7 +161,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
           secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slack_token
           exportEnv: false
       - name: Send Slack notification
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -83,8 +83,8 @@ jobs:
   #       run: "TF_LOG=info terraform apply -auto-approve -input=false ${{ env.terraform_directory }}"
   #       env:
   #         VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-  slack_notification:
-    name: Announce deployments
+  notify_deploy_start:
+    name: Announce deployments starting
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Slack token
@@ -98,10 +98,37 @@ jobs:
           secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
           exportEnv: false
       - name: Send Slack notification
-        uses: rtCamp/action-slack-notify@v2
+        id: notification
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: monster-deploy
+          status: TESTING NOTIFICATION Deploying to dev, hca, hca-prod, prod, v2f-prod
+          color: warning
         env:
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_CHANNEL: '#monster-deploy'
-          SLACK_TITLE: '[TESTING NOTIFICATION] Deployment for [dev, hca, hca-prod, prod, v2f-prod] status: ${{ job.status }}'
-          SLACK_USERNAME: "monster-deploy notifier"
-          SLACK_WEBHOOK: ${{ steps.vault-lookup.outputs.slackToken }}
+          SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slackToken }}
+    outputs:
+      message_id: ${{ steps.notification.outputs.message_id }}
+  notify_deploy_finish:
+    name: Announce deployments finishing
+    runs-on: ubuntu-latest
+    needs: notify_deploy_start
+    steps:
+      - name: Fetch Slack token
+        id: vault-lookup
+        uses: hashicorp/vault-action@v2.1.2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+          secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          exportEnv: false
+      - name: Send Slack notification
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: monster-deploy
+          status: TESTING NOTIFICATION Deployment to dev, hca, hca-prod, prod, v2f-prod COMPLETE
+          color: success
+          message_id: ${{ jobs.notify_deploy_start.outputs.message_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slackToken }}

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Send Slack notification
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: monster-deploy
+          channel_id: C01QNFFKAG2  # monster-deploy
           status: TESTING NOTIFICATION Deployment to dev, hca, hca-prod, prod, v2f-prod COMPLETE
           color: success
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -103,6 +103,7 @@ jobs:
     name: Announce deployments starting
     needs: get_slack_token
     runs-on: ubuntu-latest
+    steps:
       - name: Send Slack notification
         id: notification
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -1,85 +1,107 @@
 name: 'Apply Master Changes'
 env:
   terraform_version: "0.12.24"
-on:
-  push:
-    branches:
-      - master
+on: [push]
+  # push:
+  #   branches:
+  #     - master
 jobs:
-  terraform_apply:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-        - environment: dev
-          vault_env: dev
-          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
-          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-        - environment: hca
-          vault_env: dev
-          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
-          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
-        - environment: hca-prod
-          vault_env: prod
-          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
-          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-        - environment: prod
-          vault_env: prod
-          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
-          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-        - environment: v2f-prod
-          vault_env: prod
-          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
-          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
-    name: "${{ matrix.environment }} Terraform Apply"
+  # terraform_apply:
+  #   timeout-minutes: 30
+  #   strategy:
+  #     matrix:
+  #       include:
+  #       - environment: dev
+  #         vault_env: dev
+  #         vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+  #         vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+  #       - environment: hca
+  #         vault_env: dev
+  #         vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+  #         vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+  #       - environment: hca-prod
+  #         vault_env: prod
+  #         vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+  #         vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+  #       - environment: prod
+  #         vault_env: prod
+  #         vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+  #         vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+  #       - environment: v2f-prod
+  #         vault_env: prod
+  #         vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+  #         vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
+  #   name: "${{ matrix.environment }} Terraform Apply"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
+  #     VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+  #     GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
+  #     AWS_REGION: us-east-1
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+
+  #     - name: install terraform
+  #       uses: hashicorp/setup-terraform@v1.2.1
+  #       with:
+  #         terraform_version: ${{ env.terraform_version }}
+
+  #     - name: "${{ matrix.environment }} set VAULT_TOKEN"
+  #       id: token
+  #       run: |
+  #         VAULT_TOKEN=$(curl \
+  #           --request POST \
+  #           --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
+  #           ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
+  #         echo ::add-mask::${VAULT_TOKEN}
+  #         echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
+  #         echo ::set-output name=vault_token::${VAULT_TOKEN}
+  #       env:
+  #         ROLE_ID: ${{ secrets[matrix.vault_role_id_secret] }}
+  #         SECRET_ID: ${{ secrets[matrix.vault_secret_id_secret] }}
+
+
+  #     - name: "${{ matrix.environment }} consul-template render templates for terraform"
+  #       uses: broadinstitute/github-action-consul-template@master
+  #       with:
+  #         vault-address: ${{ secrets.VAULT_ADDR }}
+  #         vault-token: ${{ steps.token.outputs.vault_token }}
+  #         environment: ${{ matrix.vault_env }}
+  #         env_path: "environments"
+
+  #     - name: "${{ matrix.environment }} - Terraform Init"
+  #       id: init
+  #       run: terraform init ${{ env.terraform_directory }}
+  #       env:
+  #         VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+
+  #     - name: "${{ matrix.environment }} - Terraform Apply"
+  #       id: apply
+  #       run: "TF_LOG=info terraform apply -auto-approve -input=false ${{ env.terraform_directory }}"
+  #       env:
+  #         VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+  slack_notification:
+    name: Announce deployments
     runs-on: ubuntu-latest
-    env:
-      terraform_directory: "${{ github.workspace }}/environments/${{ matrix.environment }}/terraform"
-      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-      GOOGLE_APPLICATION_CREDENTIALS: "${{ github.workspace }}/environments/gcs_sa_key.json"
-      AWS_REGION: us-east-1
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: install terraform
-        uses: hashicorp/setup-terraform@v1.2.1
+      - name: Fetch Slack token
+        id: vault-lookup
+        uses: hashicorp/vault-action@v2.1.2
         with:
-          terraform_version: ${{ env.terraform_version }}
-
-      - name: "${{ matrix.environment }} set VAULT_TOKEN"
-        id: token
-        run: |
-          VAULT_TOKEN=$(curl \
-            --request POST \
-            --data '{"role_id":"'"${ROLE_ID}"'","secret_id":"'"${SECRET_ID}"'"}' \
-            ${VAULT_ADDR}/v1/auth/approle/login | jq -r .auth.client_token)
-          echo ::add-mask::${VAULT_TOKEN}
-          echo "VAULT_TOKEN=$(echo ${VAULT_TOKEN})" >> $GITHUB_ENV
-          echo ::set-output name=vault_token::${VAULT_TOKEN}
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
+          secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          exportEnv: false
+      - name: Send Slack notification
+        uses: rtCamp/action-slack-notify@v2
         env:
-          ROLE_ID: ${{ secrets[matrix.vault_role_id_secret] }}
-          SECRET_ID: ${{ secrets[matrix.vault_secret_id_secret] }}
-
-
-      - name: "${{ matrix.environment }} consul-template render templates for terraform"
-        uses: broadinstitute/github-action-consul-template@master
-        with:
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-token: ${{ steps.token.outputs.vault_token }}
-          environment: ${{ matrix.vault_env }}
-          env_path: "environments"
-
-      - name: "${{ matrix.environment }} - Terraform Init"
-        id: init
-        run: terraform init ${{ env.terraform_directory }}
-        env:
-          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-
-      - name: "${{ matrix.environment }} - Terraform Apply"
-        id: apply
-        run: "TF_LOG=info terraform apply -auto-approve -input=false ${{ env.terraform_directory }}"
-        env:
-          VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_CHANNEL: '#monster-deploy'
+          SLACK_TITLE: '[TESTING NOTIFICATION] Deployment for [dev, hca, hca-prod, prod, v2f-prod] status: ${{ job.status }}'
+          SLACK_USERNAME: "monster-deploy notifier"
+          SLACK_WEBHOOK: ${{ steps.vault-lookup.outputs.slackToken }}

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -83,8 +83,8 @@ jobs:
   #       run: "TF_LOG=info terraform apply -auto-approve -input=false ${{ env.terraform_directory }}"
   #       env:
   #         VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-  notify_deploy_start:
-    name: Announce deployments starting
+  get_slack_token:
+    name: Get Slack token
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Slack token
@@ -95,40 +95,70 @@ jobs:
           method: approle
           roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
           secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
+          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slack_token
           exportEnv: false
+    outputs:
+      slack_token: ${{ steps.vault-lookup.outputs.slack_token }}
+  notify_deploy_start:
+    name: Announce deployments starting
+    needs: get_slack_token
+    runs-on: ubuntu-latest
       - name: Send Slack notification
         id: notification
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel_id: C01QNFFKAG2  # monster-deploy
-          status: TESTING NOTIFICATION Deploying to dev, hca, hca-prod, prod, v2f-prod
+          status: |
+            DEPLOYING
+            (dev, hca, hca-prod, prod, v2f-prod)
           color: warning
         env:
-          SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slackToken }}
+          SLACK_BOT_TOKEN: ${{ needs.get_slack_token.outputs.slack_token }}
     outputs:
       message_id: ${{ steps.notification.outputs.message_id }}
-  notify_deploy_finish:
-    name: Announce deployments finishing
+  oh_no_i_broke:
+    name: Test job that always fails
     runs-on: ubuntu-latest
     needs: notify_deploy_start
     steps:
-      - name: Fetch Slack token
-        id: vault-lookup
-        uses: hashicorp/vault-action@v2.1.2
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.MONSTER_AUTH_ROLE_ID }}
-          secretId: ${{ secrets.MONSTER_AUTH_ROLE_SECRET }}
-          secrets: secret/dsde/monster/dev/slack-notifier oauth-token | slackToken
-          exportEnv: false
+      - name: blow up
+        run: aaaaaaaaaaa
+  notify_deploy_finish:
+    name: Announce deployments finishing
+    runs-on: ubuntu-latest
+    needs:
+      - get_slack_token
+      - notify_deploy_start
+      - oh_no_i_broke
+    steps:
       - name: Send Slack notification
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel_id: C01QNFFKAG2  # monster-deploy
-          status: TESTING NOTIFICATION Deployment to dev, hca, hca-prod, prod, v2f-prod COMPLETE
+          status: |
+            DEPLOYMENT COMPLETE
+            (dev, hca, hca-prod, prod, v2f-prod)
           color: success
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:
-          SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slackToken }}
+          SLACK_BOT_TOKEN: ${{ needs.get_slack_token.outputs.slack_token }}
+  notify_deploy_failure:
+    name: Announce deployments failed
+    runs-on: ubuntu-latest
+    if: "failure()&&(needs.get_slack_token.result=='success')&&(needs.notify_deploy_start.result=='success')"
+    needs:
+      - get_slack_token
+      - notify_deploy_start
+      - oh_no_i_broke
+    steps:
+      - name: Send Slack notification
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: C01QNFFKAG2  # monster-deploy
+          status: |
+            DEPLOYMENT FAILED
+            (dev, hca, hca-prod, prod, v2f-prod)
+          color: error
+          message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ needs.get_slack_token.outputs.slack_token }}

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -103,7 +103,8 @@ jobs:
         with:
           channel_id: C01QNFFKAG2  # monster-deploy
           status: |
-            DEPLOYING
+            DEPLOYMENT IN PROGRESS
+            DEPLOY FOR ENVS:
             (dev, hca, hca-prod, prod, v2f-prod)
           color: warning
         env:
@@ -115,8 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: notify_deploy_start
     steps:
-      - name: blow up
-        run: aaaaaaaaaaa
+      - name: do thing
+        run: aaaaaaaaa
   notify_deploy_finish:
     name: Announce deployments finishing
     runs-on: ubuntu-latest
@@ -139,9 +140,10 @@ jobs:
         with:
           channel_id: C01QNFFKAG2  # monster-deploy
           status: |
-            DEPLOYMENT COMPLETE
-            (dev, hca, hca-prod, prod, v2f-prod)
-          color: success
+            DEPLOYMENT SUCCESSFUL
+            DEPLOY FOR ENVS:
+            dev, hca, hca-prod, prod, v2f-prod
+          color: good
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:
           SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slack_token }}
@@ -169,8 +171,10 @@ jobs:
           channel_id: C01QNFFKAG2  # monster-deploy
           status: |
             DEPLOYMENT FAILED
-            (dev, hca, hca-prod, prod, v2f-prod)
-          color: error
+            Click Workflow to list failed environments.
+            DEPLOY FOR ENVS:
+            dev, hca, hca-prod, prod, v2f-prod
+          color: danger
           message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:
           SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slack_token }}

--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -129,6 +129,6 @@ jobs:
           channel: monster-deploy
           status: TESTING NOTIFICATION Deployment to dev, hca, hca-prod, prod, v2f-prod COMPLETE
           color: success
-          message_id: ${{ jobs.notify_deploy_start.outputs.message_id }}
+          message_id: ${{ needs.notify_deploy_start.outputs.message_id }}
         env:
           SLACK_BOT_TOKEN: ${{ steps.vault-lookup.outputs.slackToken }}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1689)

Keeps parity with behavior of the manual script

## This PR

* Adds a Github action to our terraformApply action that sends a Slack notification to monster-deploy
* Initially the notification indicates that the deploy is in progress, and it is then updated with the pass/fail status of the deployment.
* Notification includes a link to the commit being deployed as well as the workflow running the deploy (which will be linked to the triggering user)