### PR TITLE
Ep dspdc 1663 google beta provider

### DIFF
--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -6,7 +6,7 @@ resource google_storage_bucket ebi_bucket {
 }
 
 resource google_storage_bucket_iam_member ebi_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.ebi_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -17,7 +17,7 @@ resource google_storage_bucket_iam_member ebi_bucket_iam {
 }
 
 resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.ebi_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -32,7 +32,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
 module ebi_writer_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -44,7 +44,7 @@ module ebi_writer_account {
 
 # EBI is an admin on their bucket.
 resource google_storage_bucket_iam_member ebi_writer_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.ebi_bucket.name
   role     = "roles/storage.objectAdmin"
   member   = "serviceAccount:${module.ebi_writer_account.email}"
@@ -52,7 +52,7 @@ resource google_storage_bucket_iam_member ebi_writer_iam {
 
 # Both TDRs and our Dataflow SA can read from the bucket.
 resource google_storage_bucket_iam_member tdr_ebi_reader_iam {
-  provider = google-beta.target
+  provider = google.target
   for_each = toset([local.dev_repo_email, local.prod_repo_email, module.hca_dataflow_account.email])
 
   bucket = google_storage_bucket.ebi_bucket.name
@@ -62,11 +62,11 @@ resource google_storage_bucket_iam_member tdr_ebi_reader_iam {
 
 # Google's Storage Transfer Service can interact with the bucket.
 data google_storage_transfer_project_service_account sts_account {
-  provider = google-beta.target
+  provider = google.target
 }
 
 resource google_storage_bucket_iam_member sts_iam {
-  provider = google-beta.target
+  provider = google.target
   for_each = toset(["storage.legacyBucketReader", "storage.objectViewer", "storage.legacyBucketWriter"])
 
   bucket = google_storage_bucket.ebi_bucket.name
@@ -77,13 +77,13 @@ resource google_storage_bucket_iam_member sts_iam {
 
 # bucket for UCSC
 resource google_storage_bucket ucsc_bucket {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.prod_project_name}-ucsc-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member ucsc_bucket_reader_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.ucsc_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -95,7 +95,7 @@ resource google_storage_bucket_iam_member ucsc_bucket_reader_iam {
 }
 
 resource google_storage_bucket_iam_member ucsc_bucket_writer_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.ucsc_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -108,7 +108,7 @@ resource google_storage_bucket_iam_member ucsc_bucket_writer_iam {
 
 # Both TDRs and our Dataflow SA can read from the bucket.
 resource google_storage_bucket_iam_member tdr_ucsc_reader_iam {
-  provider = google-beta.target
+  provider = google.target
   for_each = toset([local.dev_repo_email, local.prod_repo_email, module.hca_dataflow_account.email])
 
   bucket = google_storage_bucket.ucsc_bucket.name
@@ -118,7 +118,7 @@ resource google_storage_bucket_iam_member tdr_ucsc_reader_iam {
 
 # temp bucket for dataflow temporary files
 resource google_storage_bucket temp_bucket {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.prod_project_name}-temp-storage"
   location = "US"
 
@@ -135,7 +135,7 @@ resource google_storage_bucket temp_bucket {
 }
 
 resource google_storage_bucket_iam_member temp_bucket_runner_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -146,7 +146,7 @@ resource google_storage_bucket_iam_member temp_bucket_runner_iam {
 }
 
 resource google_storage_bucket_iam_member hca_argo_temp_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -157,13 +157,13 @@ resource google_storage_bucket_iam_member hca_argo_temp_bucket_iam {
 
 # staging bucket
 resource google_storage_bucket staging_storage {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.prod_project_name}-staging-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member staging_bucket_runner_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -174,7 +174,7 @@ resource google_storage_bucket_iam_member staging_bucket_runner_iam {
 }
 
 resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -184,7 +184,7 @@ resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
 }
 
 resource google_storage_bucket_iam_member staging_account_iam_reader {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
   role   = "roles/storage.objectViewer"
@@ -193,13 +193,13 @@ resource google_storage_bucket_iam_member staging_account_iam_reader {
 
 # Bucket for long term Argo logs storage, currently want no "delete after N days" rule.
 resource google_storage_bucket hca_argo_archive {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.prod_project_name}-argo-archive"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.hca_argo_archive.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -212,7 +212,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 module hca_dataflow_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -225,7 +225,7 @@ module hca_dataflow_account {
 module hca_argo_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -236,11 +236,11 @@ module hca_argo_runner_account {
 }
 
 data google_project current_project {
-  provider = google-beta.target
+  provider = google.target
 }
 
 resource google_service_account_iam_binding hca_workload_identity_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_argo_runner_account.id
   role               = "roles/iam.workloadIdentityUser"
@@ -248,7 +248,7 @@ resource google_service_account_iam_binding hca_workload_identity_binding {
 }
 
 resource google_service_account_iam_binding dataflow_runner_user_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_dataflow_account.id
   role               = "roles/iam.serviceAccountUser"

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -1,6 +1,6 @@
 # bucket for EBI
 resource google_storage_bucket ebi_bucket {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.prod_project_name}-ebi-storage"
   location = "US"
 }

--- a/environments/hca-prod/terraform/cloudsql.tf
+++ b/environments/hca-prod/terraform/cloudsql.tf
@@ -1,7 +1,7 @@
 module cloudsql {
   source = "../../../templates/terraform/cloudsql"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
     vault.target  = vault.target
   }
 

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -1,5 +1,5 @@
 resource google_project_iam_custom_role argo_access {
-  provider = google-beta.target
+  provider = google.target
 
   role_id     = "argoworkflows.user"
   title       = "Argo Workflows API User"
@@ -16,7 +16,7 @@ resource google_project_iam_custom_role argo_access {
 module hca_dagster_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -32,14 +32,14 @@ module hca_dagster_runner_account {
 }
 
 resource google_project_iam_member argo_access_member {
-  provider = google-beta.target
+  provider = google.target
 
   role   = google_project_iam_custom_role.argo_access.id
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
 resource google_service_account_iam_binding kubernetes_role_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_dagster_runner_account.id
   role               = "roles/iam.workloadIdentityUser"
@@ -50,7 +50,7 @@ resource google_service_account_iam_binding kubernetes_role_binding {
 }
 
 resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -60,7 +60,7 @@ resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
 }
 
 resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -70,7 +70,7 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
 }
 
 resource google_service_account_iam_binding dataflow_runner_dagster_user_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_dataflow_account.id
   role               = "roles/iam.serviceAccountUser"

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -1,13 +1,13 @@
 data google_dns_managed_zone prod_zone {
-  provider = google-beta.prod-core
+  provider = google.prod-core
   name     = "monster-prod"
 }
 
 module dns_names {
   source = "../../../templates/terraform/dns"
   providers = {
-    google.ip  = google-beta.target,
-    google.dns = google-beta.prod-core
+    google.ip  = google.target,
+    google.dns = google.prod-core
   }
   dependencies  = [module.enable_services]
   zone_gcp_name = data.google_dns_managed_zone.prod_zone.name

--- a/environments/hca-prod/terraform/k8s.tf
+++ b/environments/hca-prod/terraform/k8s.tf
@@ -3,7 +3,7 @@
 module master {
   source = "../../../templates/terraform/k8s-master"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   dependencies = [module.enable_services, module.k8s_network]
 
@@ -21,7 +21,7 @@ module master {
 module node_pool {
   source = "../../../templates/terraform/k8s-node-pool"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   dependencies = [module.enable_services, module.master]
 
@@ -42,7 +42,7 @@ module node_pool {
 module hca_gke_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 

--- a/environments/hca-prod/terraform/networks.tf
+++ b/environments/hca-prod/terraform/networks.tf
@@ -1,7 +1,7 @@
 module k8s_network {
   source = "../../../templates/terraform/compute-network"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   dependencies = [module.enable_services]
 

--- a/environments/hca-prod/terraform/provider.tf
+++ b/environments/hca-prod/terraform/provider.tf
@@ -4,7 +4,8 @@ provider google-beta {
   project = local.prod_project_id
   region  = "us-central1"
 }
-provider google{
+
+provider google {
   alias   = "prod-core"
   project = "broad-dsp-monster-prod"
   region  = "us-central1"

--- a/environments/hca-prod/terraform/provider.tf
+++ b/environments/hca-prod/terraform/provider.tf
@@ -4,7 +4,7 @@ provider google-beta {
   project = local.prod_project_id
   region  = "us-central1"
 }
-provider google-beta {
+provider google{
   alias   = "prod-core"
   project = "broad-dsp-monster-prod"
   region  = "us-central1"

--- a/environments/hca-prod/terraform/provider.tf
+++ b/environments/hca-prod/terraform/provider.tf
@@ -10,6 +10,12 @@ provider google-beta {
   region  = "us-central1"
 }
 
+provider google {
+  alias   = "target"
+  project = local.prod_project_id
+  region  = "us-central1"
+}
+
 provider vault {
   alias = "target"
 }

--- a/environments/hca-prod/terraform/provider.tf
+++ b/environments/hca-prod/terraform/provider.tf
@@ -1,10 +1,3 @@
-provider google-beta {
-  alias = "target"
-
-  project = local.prod_project_id
-  region  = "us-central1"
-}
-
 provider google {
   alias   = "prod-core"
   project = "broad-dsp-monster-prod"

--- a/environments/hca-prod/terraform/pubsub.tf
+++ b/environments/hca-prod/terraform/pubsub.tf
@@ -11,7 +11,7 @@ module ebi_staging_notification_pubsub_topic {
 
 # EBI can consume from the EBI transfer notifications pull subscription
 resource google_pubsub_subscription_iam_member ebi_writer_iam {
-  provider     = google-beta.target
+  provider     = google.target
   subscription = "ebi-writer"
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${module.ebi_writer_account.email}"
@@ -20,7 +20,7 @@ resource google_pubsub_subscription_iam_member ebi_writer_iam {
 
 # EBI can publish to the EBI transfer notifications topic (needed for testing on their end)
 resource google_pubsub_topic_iam_member ebi_writer_iam {
-  provider = google-beta.target
+  provider = google.target
   topic    = "staging-transfer-notifications.ebi"
   role     = "roles/pubsub.publisher"
   member   = "serviceAccount:${module.ebi_writer_account.email}"

--- a/environments/hca-prod/terraform/services.tf
+++ b/environments/hca-prod/terraform/services.tf
@@ -1,7 +1,7 @@
 module enable_services {
   source = "../../../templates/terraform/api-services"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   service_ids = [
     "compute.googleapis.com",

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -1,6 +1,6 @@
 # temp bucket for dataflow temporary files
 resource google_storage_bucket temp_bucket {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.dev_project_name}-temp-storage"
   location = "US"
 
@@ -17,7 +17,7 @@ resource google_storage_bucket temp_bucket {
 }
 
 resource google_storage_bucket_iam_member temp_bucket_runner_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -28,7 +28,7 @@ resource google_storage_bucket_iam_member temp_bucket_runner_iam {
 }
 
 resource google_storage_bucket_iam_member temp_bucket_test_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -39,7 +39,7 @@ resource google_storage_bucket_iam_member temp_bucket_test_iam {
 }
 
 resource google_storage_bucket_iam_member hca_argo_temp_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -50,13 +50,13 @@ resource google_storage_bucket_iam_member hca_argo_temp_bucket_iam {
 
 # staging bucket
 resource google_storage_bucket staging_storage {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.dev_project_name}-staging-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member staging_bucket_runner_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -67,7 +67,7 @@ resource google_storage_bucket_iam_member staging_bucket_runner_iam {
 }
 
 resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -77,7 +77,7 @@ resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
 }
 
 resource google_storage_bucket_iam_member staging_account_iam_reader {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
   role   = "roles/storage.objectViewer"
@@ -86,13 +86,13 @@ resource google_storage_bucket_iam_member staging_account_iam_reader {
 
 # Bucket for long term Argo logs storage, currently want no "delete after N days" rule.
 resource google_storage_bucket hca_argo_archive {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.dev_project_name}-argo-archive"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.hca_argo_archive.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -105,7 +105,7 @@ resource google_storage_bucket_iam_member hca_argo_logs_bucket_iam {
 module hca_dataflow_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -118,7 +118,7 @@ module hca_dataflow_account {
 module hca_argo_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -129,11 +129,11 @@ module hca_argo_runner_account {
 }
 
 data google_project current_project {
-  provider = google-beta.target
+  provider = google.target
 }
 
 resource google_service_account_iam_binding hca_workload_identity_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_argo_runner_account.id
   role               = "roles/iam.workloadIdentityUser"
@@ -141,7 +141,7 @@ resource google_service_account_iam_binding hca_workload_identity_binding {
 }
 
 resource google_service_account_iam_binding dataflow_runner_user_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_dataflow_account.id
   role               = "roles/iam.serviceAccountUser"

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -1,5 +1,5 @@
 resource google_project_iam_custom_role argo_access {
-  provider = google-beta.target
+  provider = google.target
 
   role_id     = "argoworkflows.user"
   title       = "Argo Workflows API User"
@@ -16,7 +16,7 @@ resource google_project_iam_custom_role argo_access {
 module hca_dagster_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -32,14 +32,14 @@ module hca_dagster_runner_account {
 }
 
 resource google_project_iam_member argo_access_member {
-  provider = google-beta.target
+  provider = google.target
 
   role   = google_project_iam_custom_role.argo_access.id
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
 resource google_service_account_iam_binding kubernetes_role_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_dagster_runner_account.id
   role               = "roles/iam.workloadIdentityUser"
@@ -50,7 +50,7 @@ resource google_service_account_iam_binding kubernetes_role_binding {
 }
 
 resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -60,7 +60,7 @@ resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
 }
 
 resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -70,7 +70,7 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
 }
 
 resource google_service_account_iam_binding dataflow_runner_dagster_user_binding {
-  provider = google-beta.target
+  provider = google.target
 
   service_account_id = module.hca_dataflow_account.id
   role               = "roles/iam.serviceAccountUser"

--- a/environments/hca/terraform/ebi-bucket.tf
+++ b/environments/hca/terraform/ebi-bucket.tf
@@ -1,6 +1,6 @@
 # Staging bucket for EBI.
 resource google_storage_bucket ebi_staging_bucket {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.dev_project_name}-ebi-staging"
   location = "US"
 }
@@ -9,7 +9,7 @@ resource google_storage_bucket ebi_staging_bucket {
 module ebi_writer_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 
@@ -21,7 +21,7 @@ module ebi_writer_account {
 
 # EBI is an admin on their bucket.
 resource google_storage_bucket_iam_member ebi_writer_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.ebi_staging_bucket.name
   role     = "roles/storage.objectAdmin"
   member   = "serviceAccount:${module.ebi_writer_account.email}"
@@ -29,7 +29,7 @@ resource google_storage_bucket_iam_member ebi_writer_iam {
 
 # Rolando and Enrique are admin on their bucket
 resource google_storage_bucket_iam_member ebi_user_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.ebi_staging_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -41,7 +41,7 @@ resource google_storage_bucket_iam_member ebi_user_bucket_iam {
 
 # Both TDRs and our Dataflow SA can read from the bucket.
 resource google_storage_bucket_iam_member tdr_reader_iam {
-  provider = google-beta.target
+  provider = google.target
   for_each = toset([local.dev_repo_email, local.prod_repo_email, module.hca_dataflow_account.email])
 
   bucket = google_storage_bucket.ebi_staging_bucket.name
@@ -51,11 +51,11 @@ resource google_storage_bucket_iam_member tdr_reader_iam {
 
 # Google's Storage Transfer Service can interact with the bucket.
 data google_storage_transfer_project_service_account sts_account {
-  provider = google-beta.target
+  provider = google.target
 }
 
 resource google_storage_bucket_iam_member sts_iam {
-  provider = google-beta.target
+  provider = google.target
   for_each = toset(["storage.legacyBucketReader", "storage.objectViewer", "storage.legacyBucketWriter"])
 
   bucket = google_storage_bucket.ebi_staging_bucket.name

--- a/environments/hca/terraform/k8s.tf
+++ b/environments/hca/terraform/k8s.tf
@@ -3,7 +3,7 @@
 module master {
   source = "../../../templates/terraform/k8s-master"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   dependencies = [module.enable_services, module.k8s_network]
 
@@ -21,7 +21,7 @@ module master {
 module node_pool {
   source = "../../../templates/terraform/k8s-node-pool"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   dependencies = [module.enable_services, module.master]
 
@@ -42,7 +42,7 @@ module node_pool {
 module hca_gke_runner_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 

--- a/environments/hca/terraform/networks.tf
+++ b/environments/hca/terraform/networks.tf
@@ -1,7 +1,7 @@
 module k8s_network {
   source = "../../../templates/terraform/compute-network"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   dependencies = [module.enable_services]
 

--- a/environments/hca/terraform/pubsub.tf
+++ b/environments/hca/terraform/pubsub.tf
@@ -12,7 +12,7 @@ module ebi_staging_notification_pubsub_topic {
 
 # EBI can consume from the EBI transfer notifications pull subscription
 resource google_pubsub_subscription_iam_member ebi_writer_iam {
-  provider     = google-beta.target
+  provider     = google.target
   subscription = "projects/broad-dsp-monster-hca-dev/subscriptions/ebi-writer"
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${module.ebi_writer_account.email}"
@@ -21,7 +21,7 @@ resource google_pubsub_subscription_iam_member ebi_writer_iam {
 
 # EBI can publish to the EBI transfer notifications topic (needed for testing on their end)
 resource google_pubsub_topic_iam_member ebi_writer_iam {
-  provider = google-beta.target
+  provider = google.target
   topic    = "broad-dsp-monster-hca-dev.staging-transfer-notifications.ebi"
   role     = "roles/pubsub.publisher"
   member   = "serviceAccount:${module.ebi_writer_account.email}"

--- a/environments/hca/terraform/services.tf
+++ b/environments/hca/terraform/services.tf
@@ -1,7 +1,7 @@
 module enable_services {
   source = "../../../templates/terraform/api-services"
   providers = {
-    google.target = google-beta.target
+    google.target = google.target
   }
   service_ids = [
     "compute.googleapis.com",

--- a/environments/hca/terraform/sinks.tf
+++ b/environments/hca/terraform/sinks.tf
@@ -1,11 +1,11 @@
 resource google_storage_bucket logs {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.dev_project_name}-error-logs"
 }
 
 # Grant service account access to the storage bucket
 resource "google_storage_bucket_iam_member" "bucket-log-writer" {
-  provider   = google-beta.target
+  provider   = google.target
   bucket     = google_storage_bucket.logs.name
   role       = "roles/storage.objectCreator"
   member     = google_logging_project_sink.bucket-log-sink.writer_identity
@@ -13,7 +13,7 @@ resource "google_storage_bucket_iam_member" "bucket-log-writer" {
 }
 
 resource "google_logging_project_sink" "bucket-log-sink" {
-  provider               = google-beta.target
+  provider               = google.target
   name                   = "${local.dev_project_name}-gcs-log-sink"
   destination            = "storage.googleapis.com/${google_storage_bucket.logs.name}"
   filter                 = "resource.type=\"dataflow_step\" severity=ERROR jsonPayload.message : (\"SchemaValidationError\" OR \"FileMismatchError\" OR \"NoRegexPatternMatchError\" OR \"MissingPropertyError\")"

--- a/environments/hca/terraform/testing.tf
+++ b/environments/hca/terraform/testing.tf
@@ -1,12 +1,12 @@
 // create test bucket
 resource google_storage_bucket test_bucket {
-  provider = google-beta.target
+  provider = google.target
   name     = "${local.dev_project_name}-test-storage"
   location = "US"
 }
 
 resource google_storage_bucket_iam_member test_bucket_iam {
-  provider = google-beta.target
+  provider = google.target
   bucket   = google_storage_bucket.test_bucket.name
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
@@ -20,7 +20,7 @@ resource google_storage_bucket_iam_member test_bucket_iam {
 module hca_test_account {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.target,
+    google.target = google.target,
     vault.target  = vault.target
   }
 

--- a/environments/v2f-prod/terraform/bucket.tf
+++ b/environments/v2f-prod/terraform/bucket.tf
@@ -1,10 +1,10 @@
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-v2f-prod"
   region  = "us-central1"
   alias   = "v2f"
 }
 
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-dev"
   region  = "us-central1"
   alias   = "command-center"
@@ -15,7 +15,7 @@ provider vault {
 }
 
 resource google_storage_bucket v2f_results_bucket {
-  provider = google-beta.v2f
+  provider = google.v2f
   name     = "variant-to-function-result-sets"
   location = "US"
 }
@@ -23,7 +23,7 @@ resource google_storage_bucket v2f_results_bucket {
 module v2f_writer {
   source = "../../../templates/terraform/google-sa"
   providers = {
-    google.target = google-beta.command-center,
+    google.target = google.command-center,
     vault.target  = vault.v2f
   }
 
@@ -34,11 +34,11 @@ module v2f_writer {
 }
 
 data google_project command_center {
-  provider = google-beta.command-center
+  provider = google.command-center
 }
 
 resource google_storage_bucket_iam_member v2f_iam {
-  provider   = google-beta.v2f
+  provider   = google.v2f
   bucket     = google_storage_bucket.v2f_results_bucket.name
   role       = "roles/storage.objectAdmin"
   member     = "serviceAccount:${module.v2f_writer.email}"
@@ -46,7 +46,7 @@ resource google_storage_bucket_iam_member v2f_iam {
 }
 
 resource google_service_account_iam_binding v2f_binding_iam {
-  provider           = google-beta.command-center
+  provider           = google.command-center
   service_account_id = module.v2f_writer.id
   role               = "roles/iam.workloadIdentityUser"
 
@@ -54,14 +54,14 @@ resource google_service_account_iam_binding v2f_binding_iam {
 }
 
 resource google_storage_bucket_iam_member v2f_reader_iam {
-  provider = google-beta.v2f
+  provider = google.v2f
   bucket   = google_storage_bucket.v2f_results_bucket.name
   role     = "roles/storage.objectViewer"
   member   = "group:v2fcir@broadinstitute.org"
 }
 
 resource google_storage_bucket_iam_member v2f_admin_iam {
-  provider = google-beta.v2f
+  provider = google.v2f
   bucket   = google_storage_bucket.v2f_results_bucket.name
   role     = "roles/storage.objectAdmin"
   member   = "user:schaluva@broadinstitute.org"


### PR DESCRIPTION
## Why
Want to swap out our Terraform config to utilize google instead of google-beta provider
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1663)

## This PR
Swaps google-beta -> google provider and was tested locally by performing terraform plan after each change in a file