### PR TITLE
Include DAP when applying on merge

### DIFF
--- a/.github/workflows/terraformApply.yml
+++ b/.github/workflows/terraformApply.yml
@@ -15,6 +15,14 @@ jobs:
     strategy:
       matrix:
         include:
+        - environment: dap/dap-dev
+          vault_env: dev
+          vault_role_id_secret: MONSTER_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_AUTH_ROLE_SECRET
+        - environment: dap/dap-prod
+          vault_env: prod
+          vault_role_id_secret: MONSTER_PROD_AUTH_ROLE_ID
+          vault_secret_id_secret: MONSTER_PROD_AUTH_ROLE_SECRET
         - environment: dev
           vault_env: dev
           vault_role_id_secret: MONSTER_AUTH_ROLE_ID


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1710)
We are not applying terraform changes on merge to master for DAP.

## This PR
* Adds the relevant DAP envs to the matrix
