### PR TITLE
Fix pubsub IAM race 

### DIFF
--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -252,5 +252,7 @@ resource google_service_account_iam_binding dataflow_runner_user_binding {
 
   service_account_id = module.hca_dataflow_account.id
   role               = "roles/iam.serviceAccountUser"
-  members            = ["serviceAccount:${module.hca_argo_runner_account.email}", "serviceAccount:${module.hca_dagster_runner_account.email}"]
-}
+  members = [
+    "serviceAccount:${module.hca_argo_runner_account.email}",
+    "serviceAccount:${module.hca_dagster_runner_account.email}"
+  ]}

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -255,4 +255,5 @@ resource google_service_account_iam_binding dataflow_runner_user_binding {
   members = [
     "serviceAccount:${module.hca_argo_runner_account.email}",
     "serviceAccount:${module.hca_dagster_runner_account.email}"
-  ]}
+  ]
+}

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -252,5 +252,5 @@ resource google_service_account_iam_binding dataflow_runner_user_binding {
 
   service_account_id = module.hca_dataflow_account.id
   role               = "roles/iam.serviceAccountUser"
-  members            = ["serviceAccount:${module.hca_argo_runner_account.email}"]
+  members            = ["serviceAccount:${module.hca_argo_runner_account.email}", "serviceAccount:${module.hca_dagster_runner_account.email}"]
 }

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -68,11 +68,3 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   role   = "roles/storage.admin"
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
-
-resource google_service_account_iam_binding dataflow_runner_dagster_user_binding {
-  provider = google-beta.target
-
-  service_account_id = module.hca_dataflow_account.id
-  role               = "roles/iam.serviceAccountUser"
-  members            = ["serviceAccount:${module.hca_dagster_runner_account.email}"]
-}

--- a/environments/hca-prod/terraform/pubsub.tf
+++ b/environments/hca-prod/terraform/pubsub.tf
@@ -15,13 +15,15 @@ resource google_pubsub_subscription_iam_member ebi_writer_iam {
   subscription = "ebi-writer"
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${module.ebi_writer_account.email}"
+  depends_on   = [module.ebi_staging_notification_pubsub_topic]
 }
 
 
 # EBI can publish to the EBI transfer notifications topic (needed for testing on their end)
 resource google_pubsub_topic_iam_member ebi_writer_iam {
-  provider = google-beta.target
-  topic    = "staging-transfer-notifications.ebi"
-  role     = "roles/pubsub.publisher"
-  member   = "serviceAccount:${module.ebi_writer_account.email}"
+  provider   = google-beta.target
+  topic      = "staging-transfer-notifications.ebi"
+  role       = "roles/pubsub.publisher"
+  member     = "serviceAccount:${module.ebi_writer_account.email}"
+  depends_on = [module.ebi_staging_notification_pubsub_topic]
 }

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -69,11 +69,3 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
-resource google_service_account_iam_binding dataflow_runner_dagster_user_binding {
-  provider = google-beta.target
-
-  service_account_id = module.hca_dataflow_account.id
-  role               = "roles/iam.serviceAccountUser"
-  members            = ["serviceAccount:${module.hca_dagster_runner_account.email}"]
-}
-

--- a/environments/hca/terraform/pubsub.tf
+++ b/environments/hca/terraform/pubsub.tf
@@ -16,13 +16,17 @@ resource google_pubsub_subscription_iam_member ebi_writer_iam {
   subscription = "projects/broad-dsp-monster-hca-dev/subscriptions/ebi-writer"
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${module.ebi_writer_account.email}"
+  depends_on   = [module.ebi_staging_notification_pubsub_topic]
+
 }
 
 
 # EBI can publish to the EBI transfer notifications topic (needed for testing on their end)
 resource google_pubsub_topic_iam_member ebi_writer_iam {
-  provider = google-beta.target
-  topic    = "broad-dsp-monster-hca-dev.staging-transfer-notifications.ebi"
-  role     = "roles/pubsub.publisher"
-  member   = "serviceAccount:${module.ebi_writer_account.email}"
+  provider   = google-beta.target
+  topic      = "broad-dsp-monster-hca-dev.staging-transfer-notifications.ebi"
+  role       = "roles/pubsub.publisher"
+  member     = "serviceAccount:${module.ebi_writer_account.email}"
+  depends_on = [module.ebi_staging_notification_pubsub_topic]
+
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1727)
There is a race when creating the ebi staging writer pubub IAM permissions; we need to wait for subscription to be created before granting the permissions.

## This PR
* Adds a depends_on to the IAM user permission operations
* Fixes dagster dataflow user bindings so they don't get clobbered after every terraform apply