### PR TITLE
[DSPDC-1735] Add codeowners file for terraform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*.tf @aherbst-broad


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1735)
There are sensitive parts of our terraform infrastructure that require approval by the Monster tech lead.

## This PR
* Adds a `CODEOWNERS` file that sets `aherbst-broad` as the owner for any `.tf` changes, and requires a review. 
