### PR TITLE
Create buckets to store HCA dagster run records and intermediate job outputs

### DIFF
--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -49,6 +49,23 @@ resource google_service_account_iam_binding kubernetes_role_binding {
   ]
 }
 
+# Bucket for storing intermediate results from Dagster pipeline runs as well as long-term records of past runs.
+resource google_storage_bucket hca_dagster_storage {
+  provider = google.target
+  name     = "${local.prod_project_name}-dagster-storage"
+  location = "US"
+}
+
+resource google_storage_bucket_iam_member hca_dagster_run_bucket_iam {
+  provider = google.target
+  bucket   = google_storage_bucket.hca_dagster_storage.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
+}
+
 resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
   provider = google.target
   bucket   = google_storage_bucket.staging_storage.name

--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -54,6 +54,17 @@ resource google_storage_bucket hca_dagster_storage {
   provider = google.target
   name     = "${local.prod_project_name}-dagster-storage"
   location = "US"
+
+  # delete intermediate results after four weeks
+  lifecycle_rule {
+    condition {
+      age = 28
+    }
+
+    action {
+      type = "Delete"
+    }
+  }
 }
 
 resource google_storage_bucket_iam_member hca_dagster_run_bucket_iam {

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -49,6 +49,23 @@ resource google_service_account_iam_binding kubernetes_role_binding {
   ]
 }
 
+# Bucket for storing intermediate results from Dagster pipeline runs.
+resource google_storage_bucket hca_dagster_storage {
+  provider = google-beta.target
+  name     = "${local.dev_project_name}-dagster-storage"
+  location = "US"
+}
+
+resource google_storage_bucket_iam_member hca_dagster_run_bucket_iam {
+  provider = google.target
+  bucket   = google_storage_bucket.hca_dagster_storage.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
+}
+
 resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
   provider = google.target
   bucket   = google_storage_bucket.staging_storage.name

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -54,6 +54,17 @@ resource google_storage_bucket hca_dagster_storage {
   provider = google-beta.target
   name     = "${local.dev_project_name}-dagster-storage"
   location = "US"
+
+  # delete intermediate results after four weeks
+  lifecycle_rule {
+    condition {
+      age = 28
+    }
+
+    action {
+      type = "Delete"
+    }
+  }
 }
 
 resource google_storage_bucket_iam_member hca_dagster_run_bucket_iam {


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1751)

## This PR

* Creates a bucket in HCA dev and prod to store Dagster run data, and gives the Dagster runner SA permission to access the bucket.

We may want to, in the future, set up a lifecycle rule to clean up intermediate outputs after a few days-to-weeks, but intermediate outputs will (for now) be extremely small, so this is not urgent to do.