### PR TITLE
Turn off TF plan comments, reduce debug level to INFO

### DIFF
--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -106,35 +106,7 @@ jobs:
 
       - name: "${{ matrix.environment }} - Terraform Plan"
         id: plan
-        run: TF_LOG=debug terraform plan -input=false -no-color ${{ env.terraform_directory }}
+        run: TF_LOG=info terraform plan -input=false -no-color ${{ env.terraform_directory }}
         if: always()
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}
-
-      - name: Outputs
-        uses: actions/github-script@0.9.0
-        if: github.event_name == 'pull_request'
-        env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### ${{ matrix.environment }} - Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### ${{ matrix.environment }} - Terraform Validation 🤖${{ steps.validate.outputs.stdout }}
-            #### ${{ matrix.environment }} - Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-
-            <details><summary>${{ matrix.environment }} - Show Plan</summary>
-
-            \`\`\`${process.env.PLAN}\`\`\`
-
-            </details>
-
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.terraform_directory }}\`, Workflow: \`${{ github.workflow }}\`*`;
-
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })


### PR DESCRIPTION
## Why

The comments for our Terraform plans don't provide any information not available from the Github job logs, and they massively clutter our PRs.0

## This PR

* Disables comments generated by TF plan jobs
* Reduces the log level of our terraform plan jobs to INFO so the only thing displayed (by default) is the plan output.

Plans will still run and pass/fail, and we can review the results of those plans by looking at the logs of the plan step in the Github actions.