### PR TITLE
Use project ID when setting up IAM user for pubsub, not name

### DIFF
--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: "${{ matrix.environment }} - Terraform Plan"
         id: plan
-        run: TF_LOG=info terraform plan -input=false -no-color ${{ env.terraform_directory }}
+        run: terraform plan -input=false -no-color ${{ env.terraform_directory }}
         if: always()
         env:
           VAULT_TOKEN: ${{ steps.token.outputs.vault_token }}

--- a/templates/terraform/staging-storage/main.tf
+++ b/templates/terraform/staging-storage/main.tf
@@ -70,7 +70,7 @@ module staging_notification_pubsub_topic {
 
 resource google_pubsub_subscription_iam_member staging_writer_iam {
   provider     = google.target
-  subscription = "projects/${var.project_name}/subscriptions/${var.area_name}-writer"
+  subscription = "projects/${var.project_id}/subscriptions/${var.area_name}-writer"
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${module.external_writer_account.email}"
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1749)
We need to use the project ID, not the project name when setting up the pubsub IAM user.

## This PR
* Swaps project ID for name where appropriate
* Removes the INFO level logging on the `terraform plan` check as I find it a major pain to scroll for minutes to get the actual plan.
