### PR TITLE
Add dependency on pubsub topic when creating IAM writer

### DIFF
--- a/templates/terraform/staging-storage/main.tf
+++ b/templates/terraform/staging-storage/main.tf
@@ -69,6 +69,7 @@ module staging_notification_pubsub_topic {
 }
 
 resource google_pubsub_subscription_iam_member staging_writer_iam {
+  depends_on   = [module.staging_notification_pubsub_topic]
   provider     = google.target
   subscription = "projects/${var.project_id}/subscriptions/${var.area_name}-writer"
   role         = "roles/pubsub.subscriber"
@@ -76,8 +77,9 @@ resource google_pubsub_subscription_iam_member staging_writer_iam {
 }
 
 resource google_pubsub_topic_iam_member staging_writer_iam {
-  provider = google.target
-  topic    = "${var.project_name}.staging-transfer-notifications.${var.area_name}"
-  role     = "roles/pubsub.publisher"
-  member   = "serviceAccount:${module.external_writer_account.email}"
+  depends_on = [module.staging_notification_pubsub_topic]
+  provider   = google.target
+  topic      = "${var.project_name}.staging-transfer-notifications.${var.area_name}"
+  role       = "roles/pubsub.publisher"
+  member     = "serviceAccount:${module.external_writer_account.email}"
 }


### PR DESCRIPTION
## Why

The latest TF apply failed; I believe this may be due to a race between creating the IAM user and the pubsub topic to which they are being granted perms.

## This PR
* Adds a `depends_on` in the IAM user creation on the pubsub topic creation
