### PR TITLE
ra dspdc 1787 lantern group

### DIFF
--- a/environments/hca-prod/terraform/staging-buckets.tf
+++ b/environments/hca-prod/terraform/staging-buckets.tf
@@ -18,4 +18,5 @@ module lantern-staging-storage {
   vault_prefix                    = local.prod_vault_prefix
   tdr_repo_email                  = local.prod_repo_email
   hca_dataflow_email              = module.hca_dataflow_account.email
+  external_admin_group            = "lantern-hca-prod-staging-area@broadinstitute.org"
 }

--- a/environments/hca/terraform/staging-buckets.tf
+++ b/environments/hca/terraform/staging-buckets.tf
@@ -18,4 +18,5 @@ module lantern-staging-storage {
   vault_prefix                    = local.dev_vault_prefix
   tdr_repo_email                  = local.dev_repo_email
   hca_dataflow_email              = module.hca_dataflow_account.email
+  external_admin_group            = "lantern-hca-dev-staging-area@broadinstitute.org"
 }


### PR DESCRIPTION
## Why
Access should be coded in terraform and delegated to the right people; in this case, that means we should give a google group permission to access a bucket and let the google group administrators determine who can be in that group.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/<ticket_id>)

## This PR
Adds "external_admin_group" to the lantern staging buckets for dev and prod, allowing for clean, encoded access. Note that Raaid will need to remove a few emails from the bucket's access list manually after this has gone through and been checked with Lantern.