### PR TITLE
Bump controller chart version to pull in workflow YAML updating fix

### DIFF
--- a/templates/helm/argo-controller/templates/argo.yaml
+++ b/templates/helm/argo-controller/templates/argo.yaml
@@ -34,7 +34,7 @@ spec:
   chart:
     repository: https://broadinstitute.github.io/monster-helm
     name: argo-controller
-    version: 0.7.6
+    version: 0.7.7
   values:
     logs:
       bucket: {{ .Values.artifactBucket }}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1838)
We need to pull in this fix to avoid workflows hanging when Argo attempts to PATCH gigantic YAML files in the K8S API.

## This PR
* Pulls in the fix, which will use a database rather than K8S as it's persistent store for workflow state.
