### PR TITLE
[DSPDC-1840] Bump chart version

### DIFF
--- a/templates/helm/argo-controller/Chart.yaml
+++ b/templates/helm/argo-controller/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: argo-controller
 description: Value-template for deploying an Argo controller instance.
-version: 0.0.1
+version: 0.0.2

--- a/templates/helm/orchestration-workflows/clinvar/Chart.yaml
+++ b/templates/helm/orchestration-workflows/clinvar/Chart.yaml
@@ -4,6 +4,6 @@ description: Argo workflow for regular ingest of ClinVar archives.
 version: 0.0.0
 dependencies:
   - name: argo-controller
-    version: 0.0.1
+    version: 0.0.2
     repository: file:///charts/argo-controller
     alias: argo

--- a/templates/helm/orchestration-workflows/hca-mvp/Chart.yaml
+++ b/templates/helm/orchestration-workflows/hca-mvp/Chart.yaml
@@ -4,6 +4,6 @@ description: Argo workflow for regular ingest of HCA data.
 version: 0.0.0
 dependencies:
   - name: argo-controller
-    version: 0.0.1
+    version: 0.0.2
     repository: file:///charts/argo-controller
     alias: argo


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1840)
We need to pull in the node offload fix for argo to the clinvar cluster.

## This PR
* Updates the clinvar chart to pull in the updated controller version with updated settings
* Updates the hca-mvp chart to pull in the updated controller (this has already been done in prod, this is retroactive to sync up with reality)

