### PR TITLE
Bump clinvar version and argo version

### DIFF
--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.3.4
+  ref: 1.4.0
 repo:
   url: https://jade-terra.datarepo-prod.broadinstitute.org
   dataProject: broad-datarepo-terra-prod-cgen

--- a/templates/helm/argo-controller/templates/argo.yaml
+++ b/templates/helm/argo-controller/templates/argo.yaml
@@ -34,7 +34,7 @@ spec:
   chart:
     repository: https://broadinstitute.github.io/monster-helm
     name: argo-controller
-    version: 0.7.7
+    version: 0.8.1
   values:
     logs:
       bucket: {{ .Values.artifactBucket }}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1858)
The previous fix that set the argo controller to store workflow status in the DB got clobbered because the changes were never committed to source control.

## This PR
* Bumps the argo controller and clinvar versions to reflect reality