### PR TITLE
Bump clinvar version

### DIFF
--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-dev-argo-archive
 chart:
   git: false
-  ref: 1.3.4
+  ref: 1.4.1
 repo:
   url: https://jade.datarepo-dev.broadinstitute.org
   dataProject: broad-jade-dev-data

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.4.0
+  ref: 1.4.1
 repo:
   url: https://jade-terra.datarepo-prod.broadinstitute.org
   dataProject: broad-datarepo-terra-prod-cgen


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1864)
We need to be resilient to BQ 502s.

## This PR
* Pulls in the latest clinvar version with BQ 502 fixes.
