### PR TITLE
Remove ebi dev stage writer from prod

### DIFF
--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -22,7 +22,6 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  for_each = toset()
 
   role   = "roles/storage.admin"
   member = "serviceAccount:${each.value}"

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -22,7 +22,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  for_each = toset(["ebi-staging-writer@broad-dsp-monster-hca-dev.iam.gserviceaccount.com"])
+  for_each = toset()
 
   role   = "roles/storage.admin"
   member = "serviceAccount:${each.value}"

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -22,6 +22,7 @@ resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  for_each = toset([])
 
   role   = "roles/storage.admin"
   member = "serviceAccount:${each.value}"

--- a/environments/hca-prod/terraform/buckets.tf
+++ b/environments/hca-prod/terraform/buckets.tf
@@ -16,18 +16,6 @@ resource google_storage_bucket_iam_member ebi_bucket_iam {
   member = "group:ingest-team@data.humancellatlas.org"
 }
 
-resource google_storage_bucket_iam_member ebi_sa_bucket_iam {
-  provider = google.target
-  bucket   = google_storage_bucket.ebi_bucket.name
-  # When the storage.admin role is applied to an individual bucket,
-  # the control applies only to the specified bucket and objects within
-  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
-  for_each = toset([])
-
-  role   = "roles/storage.admin"
-  member = "serviceAccount:${each.value}"
-}
-
 # Service account for EBI to use when writing to the bucket.
 module ebi_writer_account {
   source = "../../../templates/terraform/google-sa"


### PR DESCRIPTION
## Why
Dev GCP service account for exporter has access to the prod bucket and need to remove that permission
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1863)

## This PR
removes 
"client_email": "ebi-staging-writer@broad-dsp-monster-hca-dev.iam.gserviceaccount.com"
from hca-prod