### PR TITLE
Add K8S monster dagster role bindings

### DIFF
--- a/environments/dev/terraform/dagster.tf
+++ b/environments/dev/terraform/dagster.tf
@@ -1,0 +1,28 @@
+module dagster_runner_service_account {
+  source = "../../../templates/terraform/google-sa"
+  providers = {
+    google.target = google.command-center,
+    vault.target  = vault.command-center
+  }
+
+  account_id   = "monsteer-dagster-runner"
+  display_name = "Service account to run Dagster pipelines."
+  vault_path   = "${local.vault_prefix}/service-accounts/dagster-runner"
+  roles = [
+    "dataflow.developer",
+    "compute.viewer",
+    "bigquery.jobUser",
+    "bigquery.dataOwner",
+  ]
+}
+
+resource google_service_account_iam_binding kubernetes_role_binding {
+  provider = google.command-center
+
+  service_account_id = module.dagster_runner_service_account.id
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${local.dev_project_name}.svc.id.goog[dagster/monster-dagster]"
+  ]
+}

--- a/environments/dev/terraform/dagster.tf
+++ b/environments/dev/terraform/dagster.tf
@@ -5,7 +5,7 @@ module dagster_runner_service_account {
     vault.target  = vault.command-center
   }
 
-  account_id   = "monsteer-dagster-runner"
+  account_id   = "monster-dagster-runner"
   display_name = "Service account to run Dagster pipelines."
   vault_path   = "${local.vault_prefix}/service-accounts/dagster-runner"
   roles = [

--- a/environments/dev/terraform/variables.tf
+++ b/environments/dev/terraform/variables.tf
@@ -1,3 +1,4 @@
 locals {
-  vault_prefix = "secret/dsde/monster/dev"
+  dev_project_name = "broad-dsp-monster-dev"
+  vault_prefix     = "secret/dsde/monster/dev"
 }

--- a/environments/prod/terraform/dagster.tf
+++ b/environments/prod/terraform/dagster.tf
@@ -5,7 +5,7 @@ module dagster_runner_service_account {
     vault.target  = vault.command-center
   }
 
-  account_id   = "monsteer-dagster-runner"
+  account_id   = "monster-dagster-runner"
   display_name = "Service account to run Dagster pipelines."
   vault_path   = "${local.vault_prefix}/service-accounts/dagster-runner"
   roles = [

--- a/environments/prod/terraform/dagster.tf
+++ b/environments/prod/terraform/dagster.tf
@@ -1,0 +1,28 @@
+module dagster_runner_service_account {
+  source = "../../../templates/terraform/google-sa"
+  providers = {
+    google.target = google.command-center,
+    vault.target  = vault.command-center
+  }
+
+  account_id   = "monsteer-dagster-runner"
+  display_name = "Service account to run Dagster pipelines."
+  vault_path   = "${local.vault_prefix}/service-accounts/dagster-runner"
+  roles = [
+    "dataflow.developer",
+    "compute.viewer",
+    "bigquery.jobUser",
+    "bigquery.dataOwner",
+  ]
+}
+
+resource google_service_account_iam_binding kubernetes_role_binding {
+  provider = google.command-center
+
+  service_account_id = module.dagster_runner_service_account.id
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${local.prod_project_name}.svc.id.goog[dagster/monster-dagster]"
+  ]
+}

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -1,4 +1,4 @@
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-prod"
   region  = "us-central1"
   alias   = "command-center"
@@ -8,13 +8,13 @@ provider vault {
   alias = "command-center"
 }
 
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-clingen-prod"
   region  = "us-central1"
   alias   = "clinvar"
 }
 
-provider google-beta {
+provider google {
   project = "broad-dsp-monster-encode-prod"
   region  = "us-west1"
   alias   = "encode"
@@ -28,10 +28,10 @@ provider aws {
 module monster_infrastructure {
   source = "../../../templates/terraform/monster-infrastructure"
   providers = {
-    google.command-center = google-beta.command-center
+    google.command-center = google.command-center
     vault.target          = vault.command-center
-    google.clinvar        = google-beta.clinvar
-    google.encode         = google-beta.encode,
+    google.clinvar        = google.clinvar
+    google.encode         = google.encode,
     aws.encode            = aws.encode
   }
 

--- a/environments/prod/terraform/variables.tf
+++ b/environments/prod/terraform/variables.tf
@@ -1,4 +1,4 @@
 locals {
   prod_project_name = "broad-dsp-monster-prod"
-  vault_prefix     = "secret/dsde/monster/prod"
+  vault_prefix      = "secret/dsde/monster/prod"
 }

--- a/environments/prod/terraform/variables.tf
+++ b/environments/prod/terraform/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  prod_project_name = "broad-dsp-monster-prod"
+  vault_prefix     = "secret/dsde/monster/prod"
+}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1891)
We need IAM users for the monster "command center" dagster K8S service accounts so we can grant them the appropriate
permissions in the DAP GCP project.

## This PR
* Adds the role binding terraform