### PR TITLE
Set permissions on dap run storage bucket

### DIFF
--- a/environments/dap/base/infrastructure.tf
+++ b/environments/dap/base/infrastructure.tf
@@ -95,7 +95,7 @@ resource google_storage_bucket_iam_member storage_bucket_iam {
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
   role       = "roles/storage.admin"
-  member     =  each.value
+  member     = each.value
   depends_on = [module.dap_dataflow_account.delay]
 }
 

--- a/environments/dap/base/infrastructure.tf
+++ b/environments/dap/base/infrastructure.tf
@@ -87,14 +87,15 @@ resource google_storage_bucket_iam_member temp_bucket_runner_iam {
   depends_on = [module.dap_dataflow_account.delay]
 }
 
-resource google_storage_bucket_iam_member storage_bucket_dataflow_runner_iam {
+resource google_storage_bucket_iam_member storage_bucket_iam {
   provider = google.target
   bucket   = google_storage_bucket.storage_bucket.name
+  for_each = toset(["serviceAccount:${module.dap_dataflow_account.email}", "serviceAccount:${var.dagster_runner_email}"])
   # When the storage.admin role is applied to an individual bucket,
   # the control applies only to the specified bucket and objects within
   # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
   role       = "roles/storage.admin"
-  member     = "serviceAccount:${module.dap_dataflow_account.email}"
+  member     =  each.value
   depends_on = [module.dap_dataflow_account.delay]
 }
 


### PR DESCRIPTION
## Why
The dagster runner needs permissions to write to the DAP storage bucket.

## This PR
* Sets the correct permissions
