### PR TITLE
Update clinvar deployment info

### DIFF
--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-dev-argo-archive
 chart:
   git: false
-  ref: 1.4.6
+  ref: 1.4.7
 repo:
   url: https://jade.datarepo-dev.broadinstitute.org
   dataProject: broad-jade-dev-data
@@ -15,7 +15,8 @@ repo:
   datasetId: 9952ebf2-65d9-44b7-b5a8-b500bc458909
   profileId: 390e7a85-d47f-4531-b612-165fc977d3bd
 notification:
+  channelId: monster-ci
   onlyOnFailure: false
   vaultSecret:
     path: secret/dsde/monster/dev/slack-notifier
-    key: monster-ci-url
+    key: oauth-token

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.4.6
+  ref: 1.4.7
 repo:
   url: https://jade-terra.datarepo-prod.broadinstitute.org
   dataProject: broad-datarepo-terra-prod-cgen
@@ -15,7 +15,8 @@ repo:
   datasetId: dfbd0c7e-088b-45ab-a161-7b79aa28d872
   profileId: 5c001e19-ea18-41e4-8671-de42503fadcc
 notification:
+  channelId: clinvar-ingest
   onlyOnFailure: false
   vaultSecret:
     path: secret/dsde/monster/prod/clingen/slack-notifier
-    key: url
+    key: oauth-token

--- a/templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml
+++ b/templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml
@@ -25,7 +25,7 @@ spec:
       - secretName: slack-info
         nameSpace: clinvar
         vals:
-          - kubeSecretKey: slack-url
+          - kubeSecretKey: oauth-token
             {{- with .Values.notification.vaultSecret }}
             path: {{ .path }}
             vaultKey: {{ .key }}
@@ -107,10 +107,11 @@ spec:
       subnetName: monster-processing-network
       workerAccount: dataflow-runner@{{ $project }}.iam.gserviceaccount.com
     notification:
+      channelId: {{ .Values.notification.channelId }}
       onlyOnFailure: {{ .Values.notification.onlyOnFailure }}
-      slackUrl:
+      oauthToken:
         secretName: slack-info
-        secretKey: slack-url
+        secretKey: oauth-token
     clingen:
       project: {{ $project }}
       gcsBucket: {{ $project }}-ingest-results


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1902)
To support dual writing, we are going to need to create a new "real prod" clinvar deployment. This notifications from this deployment should not ping the regular #clinvar-ingest channel to avoid confusion. 

## This PR
* Updates the clinvar values.yaml to thread through the channel ID

Note that the channel_id inclusion in the chart is now supported in clinvar 1.4.7, implemented in this pr https://github.com/DataBiosphere/clinvar-ingest/pull/96