### PR TITLE
Add dagster runner SA permissions to EBI staging bucket

### DIFF
--- a/environments/hca-prod/terraform/dagster.tf
+++ b/environments/hca-prod/terraform/dagster.tf
@@ -97,15 +97,15 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
-resource google_storage_bucket hca_dcp_release_bucket {
+resource google_storage_bucket hca_dcp_etl_partitions_bucket {
   provider = google.target
-  name     = "${local.prod_project_name}-dcp-releases"
+  name     = "${local.prod_project_name}-etl-partitions"
   location = "US"
 }
 
-resource google_storage_bucket_iam_member hca_dagster_dcp_release_bucket_iam {
+resource google_storage_bucket_iam_member hca_dagster_dcp_hca_dcp_etl_partitions_bucket_iam {
   provider = google.target
-  bucket   = google_storage_bucket.hca_dcp_release_bucket.name
+  bucket   = google_storage_bucket.hca_dcp_etl_partitions_bucket.name
   role     = "roles/storage.admin"
   member   = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }

--- a/environments/hca-prod/terraform/dns.tf
+++ b/environments/hca-prod/terraform/dns.tf
@@ -12,5 +12,5 @@ module dns_names {
   dependencies  = [module.enable_services]
   zone_gcp_name = data.google_dns_managed_zone.prod_zone.name
   zone_dns_name = data.google_dns_managed_zone.prod_zone.dns_name
-  dns_names     = ["hca-argo", "hca-grafana"]
+  dns_names     = ["hca-argo"]
 }

--- a/environments/hca/terraform/buckets.tf
+++ b/environments/hca/terraform/buckets.tf
@@ -55,6 +55,13 @@ resource google_storage_bucket staging_storage {
   location = "US"
 }
 
+# staging bucket (us-central1)
+resource google_storage_bucket staging_storage_uc1 {
+  provider = google.target
+  name     = "${local.dev_project_name}-staging-storage-uc1"
+  location = "us-central1"
+}
+
 resource google_storage_bucket_iam_member staging_bucket_runner_iam {
   provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
@@ -65,6 +72,18 @@ resource google_storage_bucket_iam_member staging_bucket_runner_iam {
   member     = "serviceAccount:${module.hca_dataflow_account.email}"
   depends_on = [module.hca_dataflow_account.delay]
 }
+
+resource google_storage_bucket_iam_member staging_uc1_bucket_runner_iam {
+  provider = google.target
+  bucket   = google_storage_bucket.staging_storage_uc1.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role       = "roles/storage.admin"
+  member     = "serviceAccount:${module.hca_dataflow_account.email}"
+  depends_on = [module.hca_dataflow_account.delay]
+}
+
 
 resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
   provider = google.target
@@ -79,6 +98,14 @@ resource google_storage_bucket_iam_member hca_argo_staging_bucket_iam {
 resource google_storage_bucket_iam_member staging_account_iam_reader {
   provider = google.target
   bucket   = google_storage_bucket.staging_storage.name
+  # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${local.dev_repo_email}"
+}
+
+resource google_storage_bucket_iam_member staging_uc1_account_iam_reader {
+  provider = google.target
+  bucket   = google_storage_bucket.staging_storage_uc1.name
   # Object viewer gives both 'list' and 'get' permissions to all objects in the bucket.
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${local.dev_repo_email}"

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -87,6 +87,17 @@ resource google_storage_bucket_iam_member hca_dagster_staging_bucket_iam {
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
+resource google_storage_bucket_iam_member hca_dagster_staging_uc1_bucket_iam {
+  provider = google.target
+  bucket   = google_storage_bucket.staging_storage_uc1.name
+  # When the storage.admin role is applied to an individual bucket,
+  # the control applies only to the specified bucket and objects within
+  # the bucket: https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${module.hca_dagster_runner_account.email}"
+}
+
+
 resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   provider = google.target
   bucket   = google_storage_bucket.temp_bucket.name

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -97,6 +97,13 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
+resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
+  provider = google.target
+  bucket   = google_storage_bucket.ebi_staging_bucket.name
+  role     = "roles/storage.admin"
+  member   = "serviceAccount:${module.hca_dagster_runner_account.email}"
+}
+
 
 resource google_storage_bucket hca_dcp_release_bucket {
   provider = google.target

--- a/environments/hca/terraform/dagster.tf
+++ b/environments/hca/terraform/dagster.tf
@@ -97,7 +97,7 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
   member = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }
 
-resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
+resource google_storage_bucket_iam_member hca_dagster_ebi_staging_bucket_iam {
   provider = google.target
   bucket   = google_storage_bucket.ebi_staging_bucket.name
   role     = "roles/storage.admin"
@@ -105,15 +105,15 @@ resource google_storage_bucket_iam_member hca_dagster_temp_bucket_iam {
 }
 
 
-resource google_storage_bucket hca_dcp_release_bucket {
+resource google_storage_bucket hca_dcp_etl_partitions_bucket {
   provider = google.target
-  name     = "${local.dev_project_name}-dcp-releases"
+  name     = "${local.dev_project_name}-etl-partitions"
   location = "US"
 }
 
-resource google_storage_bucket_iam_member hca_dagster_dcp_release_bucket_iam {
+resource google_storage_bucket_iam_member hca_dagster_dcp_hca_dcp_etl_partitions_bucket_iam {
   provider = google.target
-  bucket   = google_storage_bucket.hca_dcp_release_bucket.name
+  bucket   = google_storage_bucket.hca_dcp_etl_partitions_bucket.name
   role     = "roles/storage.admin"
   member   = "serviceAccount:${module.hca_dagster_runner_account.email}"
 }

--- a/environments/hca/terraform/dns.tf
+++ b/environments/hca/terraform/dns.tf
@@ -12,5 +12,5 @@ module dns_names {
   dependencies  = [module.enable_services]
   zone_gcp_name = data.google_dns_managed_zone.dev_zone.name
   zone_dns_name = data.google_dns_managed_zone.dev_zone.dns_name
-  dns_names     = ["hca-argo", "hca-grafana", "hca-argocd"]
+  dns_names     = ["hca-argo"]
 }

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.5.0
+  ref: 1.5.3
 repo:
   url: https://jade-terra.datarepo-prod.broadinstitute.org
   dataProject: broad-datarepo-terra-prod-cgen
@@ -21,6 +21,7 @@ altRepo:
   datasetId: 29844445-5005-4672-a2f1-f238de23dc20
   profileId: 53cf7db4-1ac5-4a83-b204-95d2fea68ff1
 notification:
+  altChannelId: clinvar-migration-notifications
   channelId: clinvar-ingest
   onlyOnFailure: false
   vaultSecret:


### PR DESCRIPTION
## Why

We need to be able to read from the EBI staging bucket in DEV from our dagster pipelines.

## This PR
* Adds the needed permission
* Renames the etl partitions bucket to reflect reality
