### PR TITLE
[DSPDC-1739] Clinvar version 1.5.4

### DIFF
--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -1,5 +1,5 @@
 enable: true
-schedule: '0 13 * * *'
+schedule: '0 20 * * *'
 argo:
   env: dev
   vaultPrefix: secret/dsde/monster/dev/command-center

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -1,5 +1,5 @@
 enable: true
-schedule: '0 13 * * *'
+schedule: '0 20 * * *'
 argo:
   env: prod
   vaultPrefix: secret/dsde/monster/prod/command-center


### PR DESCRIPTION
Bump clinvar to v1.5.4 to pull in the latest ingest-utils.