### PR TITLE
Add DAP slack token to config

### DIFF
--- a/templates/helmfile/monster_comand_center_dagster.yaml
+++ b/templates/helmfile/monster_comand_center_dagster.yaml
@@ -35,6 +35,10 @@ releases:
               - kubeSecretKey: REDCAP_BASE_API_TOKEN
                 path: secret/dsde/monster/{{ requiredEnv "ENV" }}/dog-aging/redcap-tokens/automation
                 vaultKey: token
+              - kubeSecretKey: SLACK_TOKEN
+                path: secret/dsde/monster/{{ requiredEnv "ENV" }}/dog-aging/dagster
+                vaultKey: slack-token
+
   - name: monster    # release name
     namespace: dagster   # target namespace
     chart: dagster/dagster   # chart name


### PR DESCRIPTION
## Why

We need to be able to ping Slack for DAP pipeline runs.

## This PR
* Adds the slack token from the relevant vault path