### PR TITLE
Setup Dagster log storage

### DIFF
--- a/templates/helmfile/environment/dev.yaml
+++ b/templates/helmfile/environment/dev.yaml
@@ -10,3 +10,11 @@ dagit:
   env: *envConfig
 dagsterDaemon:
   env: *envConfig
+
+# capture stdout + stderr to a GCS file so we can debug if needed
+computeLogManager:
+  type: GCSComputeLogManager
+  config:
+    gcsComputeLogManager:
+      bucket: broad-dsp-monster-dev-dagster-storage
+      prefix: logs

--- a/templates/helmfile/environment/prod.yaml
+++ b/templates/helmfile/environment/prod.yaml
@@ -10,3 +10,11 @@ dagit:
   env: *envConfig
 dagsterDaemon:
   env: *envConfig
+
+# capture stdout + stderr to a GCS file so we can debug if needed
+computeLogManager:
+  type: GCSComputeLogManager
+  config:
+    gcsComputeLogManager:
+      bucket: broad-dsp-monster-prod-dagster-storage
+      prefix: logs


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1954)
We need to capture stderr + stdout from our Dagster runs to ease debugging.

## This PR
* Sets up a compute log manager and points at the dagster log storage buckets
