### PR TITLE
Increases download and extract size

### DIFF
--- a/templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml
+++ b/templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml
@@ -71,8 +71,8 @@ spec:
     {{- end}}
   {{- end}}
     volumes:
-      downloadSize: 2Gi
-      extractSize: 15Gi
+      downloadSize: 5Gi
+      extractSize: 40Gi
     staging:
       gcsBucket: {{ $project }}-staging-storage
       bigquery:


### PR DESCRIPTION
## Why

The automated nightly ClinVAR ingest failed the past two nights. Upon investigation, it was found that an IO exception was being thrown in the "extra-xml" step of the pipeline due to there being "No space left on device". Digging in a bit, we found that the downloadSize and extractSize volume parameters in templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml needed to be increased.

[Relevant ticket](https://broadworkbench.atlassian.net/browse/DI-9)

## This PR

Increases the downloadSize and extractSize volume parameters in templates/helm/orchestration-workflows/clinvar/templates/workflow.yaml to accommodate the growing size of the ClinVAR archives. The increases are from 2Gi to 5Gi and from 15Gi to 40Gi, respectively.