### PR TITLE
Fix clinvar values to remove dual writer references

### DIFF
--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -9,7 +9,7 @@ chart:
   # no "pinned version" in dev to prevent execution of the export-diffs
   # portion of the pipeline in that env
   git: false
-  ref: 1.6.41
+  ref: 1.6.45
 repo:
   url: https://jade.datarepo-dev.broadinstitute.org
   dataProject: datarepo-dev-9b9b37c6

--- a/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/dev/helm/orchestration-workflows/clinvar/values.yaml
@@ -9,14 +9,8 @@ chart:
   # no "pinned version" in dev to prevent execution of the export-diffs
   # portion of the pipeline in that env
   git: false
-  ref: 1.5.6
+  ref: 1.6.41
 repo:
-  url: https://jade.datarepo-dev.broadinstitute.org
-  dataProject: broad-jade-dev-data
-  datasetName: monster_clinvar
-  datasetId: 9952ebf2-65d9-44b7-b5a8-b500bc458909
-  profileId: 390e7a85-d47f-4531-b612-165fc977d3bd
-altRepo:
   url: https://jade.datarepo-dev.broadinstitute.org
   dataProject: datarepo-dev-9b9b37c6
   datasetName: clinvar_temp

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.6.41
+  ref: 1.6.45
 repo:
   url: https://data.terra.bio
   dataProject: datarepo-4c7e3eea

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.5.9
+  ref: 1.6.0
 repo:
   url: https://data.terra.bio
   dataProject: datarepo-4c7e3eea

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,14 +7,8 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.5.6
+  ref: 1.5.9
 repo:
-  url: https://jade-terra.datarepo-prod.broadinstitute.org
-  dataProject: broad-datarepo-terra-prod-cgen
-  datasetName: broad_dsp_clinvar
-  datasetId: dfbd0c7e-088b-45ab-a161-7b79aa28d872
-  profileId: 5c001e19-ea18-41e4-8671-de42503fadcc
-altRepo:
   url: https://data.terra.bio
   dataProject: datarepo-4c7e3eea
   datasetName: broad_dsp_clinvar

--- a/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
+++ b/environments/prod/helm/orchestration-workflows/clinvar/values.yaml
@@ -7,7 +7,7 @@ argo:
   artifactBucket: broad-dsp-monster-clingen-prod-argo-archive
 chart:
   git: false
-  ref: 1.6.0
+  ref: 1.6.41
 repo:
   url: https://data.terra.bio
   dataProject: datarepo-4c7e3eea


### PR DESCRIPTION
## Context
The dual writer flow is no more, and we should be pointing at the latest clinvar version.

## This PR
* Updates the clinvar version in dev and prod
* Removes unneeded chart values related to the dual writer